### PR TITLE
HarfBuzz integration [WIP]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,17 @@ version = "0.0.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 
+[features]
+# Enable shaping. Prefer to depend on "shaping" since we may replace harfbuzz_rs.
+shaping = ["harfbuzz_rs"]
+
 [dependencies]
 ab_glyph = "0.2.2"
 font-kit = "0.8.0"
 lazy_static = "1.4.0"
 smallvec = "1.4.1"
 xi-unicode = "0.2.1"
+
+[dependencies.harfbuzz_rs]
+version = "1.1.2"
+optional = true

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -71,26 +71,20 @@ impl FontLibrary {
     }
 
     /// Get a scaled font
-    pub fn get_scaled(&self, font_id: FontId, font_scale: PxScale) -> PxScaleFont<Font> {
-        ab_glyph::Font::into_scaled(self.get(font_id), font_scale)
+    ///
+    /// Scale units: the same as [`PxScale`] (pixels per line height).
+    pub fn get_scaled(&self, font_id: FontId, font_scale: f32) -> PxScaleFont<Font> {
+        ab_glyph::Font::into_scaled(self.get(font_id), PxScale::from(font_scale))
     }
 
     /// Get a HarfBuzz font face
     ///
-    /// This actually makes an instance on usage, which may be inefficient(?).
+    /// `font_scale` should be "point size × screen DPI / 72" (units: px/em).
     #[cfg(feature = "harfbuzz_rs")]
-    pub fn get_harfbuzz(
-        &self,
-        id: FontId,
-        scale: PxScale,
-    ) -> harfbuzz_rs::Owned<harfbuzz_rs::Font<'static>> {
+    pub fn get_harfbuzz(&self, id: FontId) -> harfbuzz_rs::Owned<harfbuzz_rs::Font<'static>> {
         let fonts = self.fonts.read().unwrap();
         assert!(id.get() < fonts.len(), "FontLibrary: invalid {:?}!", id);
-        let face = fonts[id.get()].harfbuzz.clone();
-        let mut font = harfbuzz_rs::Font::new(face);
-        // TODO: is this conversion correct?
-        font.set_ppem(scale.x as u32, scale.y as u32);
-        font
+        harfbuzz_rs::Font::new(fonts[id.get()].harfbuzz.clone())
     }
 
     /// Get a list of all fonts

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -5,7 +5,7 @@
 
 //! KAS Rich-Text library — fonts
 
-use ab_glyph::FontRef;
+use ab_glyph::{FontRef, PxScale, PxScaleFont};
 use font_kit::source::SystemSource;
 use font_kit::{family_name::FamilyName, handle::Handle, properties::Properties};
 use std::collections::HashMap;
@@ -46,13 +46,17 @@ pub struct FontLibrary {
 // public API
 impl FontLibrary {
     /// Get a font from its identifier
-    pub fn get<I: Into<FontId>>(&self, id: I) -> Font {
+    pub fn get(&self, id: FontId) -> Font {
         let fonts = self.fonts.read().unwrap();
-        let id = id.into();
         assert!(id.get() < fonts.len(), "FontLibrary: invalid {:?}!", id);
         let font: &FontRef<'static> = &fonts[id.get()];
         // Safety: elements of self.fonts are never dropped or modified
         unsafe { extend_lifetime(font) }
+    }
+
+    /// Get a scaled font
+    pub fn get_scaled(&self, font_id: FontId, font_scale: PxScale) -> PxScaleFont<Font> {
+        ab_glyph::Font::into_scaled(self.get(font_id), font_scale)
     }
 
     /// Get a list of all fonts

--- a/src/prepared.rs
+++ b/src/prepared.rs
@@ -149,18 +149,20 @@ impl Text {
     /// Calculates glyph layouts for use.
     pub fn prepare(&mut self) {
         let action = self.action;
+        if action == Action::None {
+            return;
+        }
 
         if action >= Action::Runs {
             self.prepare_runs();
         }
 
         if action >= Action::Shape {
+            let dpem = self.env.pt_size * self.env.dpp;
             self.glyph_runs = self
                 .runs
                 .iter()
-                .map(|run| {
-                    shaper::shape(self.font_id, self.env.font_scale.into(), &self.text, &run)
-                })
+                .map(|run| shaper::shape(self.font_id, dpem, &self.text, &run))
                 .collect();
         }
 
@@ -196,7 +198,7 @@ impl Text {
 
             for mut glyph in run.glyphs[run_part.glyph_range.to_std()].iter().cloned() {
                 glyph.position = glyph.position + run_part.offset;
-                glyphs.push(f(text, font_id, font_scale, glyph));
+                glyphs.push(f(text, font_id, font_scale.into(), glyph));
             }
         }
         glyphs

--- a/src/prepared.rs
+++ b/src/prepared.rs
@@ -7,7 +7,7 @@
 
 use smallvec::SmallVec;
 
-use ab_glyph::{Font, PxScale, ScaleFont};
+use ab_glyph::{PxScale, ScaleFont};
 
 use crate::{fonts, rich, shaper, FontId, Glyph, Vec2};
 use crate::{Environment, UpdateEnv};
@@ -357,9 +357,7 @@ impl Text {
                 }
             }
 
-            let sf = fonts()
-                .get(glyph_run.font_id)
-                .into_scaled(glyph_run.font_scale);
+            let sf = fonts().get_scaled(glyph_run.font_id, glyph_run.font_scale);
             let pos = run_part.offset + pos;
             return Some((pos, sf.ascent(), sf.descent()));
         }
@@ -578,10 +576,7 @@ impl Text {
                 }
             };
 
-            let sf = fonts()
-                .get(glyph_run.font_id)
-                .into_scaled(glyph_run.font_scale);
-
+            let sf = fonts().get_scaled(glyph_run.font_id, glyph_run.font_scale);
             start_pos.1 -= sf.ascent();
             end_pos.1 -= sf.descent();
             rects.push((run_part.offset + start_pos, run_part.offset + end_pos));

--- a/src/prepared.rs
+++ b/src/prepared.rs
@@ -359,7 +359,7 @@ impl Text {
                 }
             }
 
-            let sf = fonts().get_scaled(glyph_run.font_id, glyph_run.font_scale);
+            let sf = fonts().get(glyph_run.font_id).scaled(glyph_run.font_scale);
             let pos = run_part.offset + pos;
             return Some((pos, sf.ascent(), sf.descent()));
         }
@@ -578,7 +578,7 @@ impl Text {
                 }
             };
 
-            let sf = fonts().get_scaled(glyph_run.font_id, glyph_run.font_scale);
+            let sf = fonts().get(glyph_run.font_id).scaled(glyph_run.font_scale);
             start_pos.1 -= sf.ascent();
             end_pos.1 -= sf.descent();
             rects.push((run_part.offset + start_pos, run_part.offset + end_pos));

--- a/src/prepared.rs
+++ b/src/prepared.rs
@@ -126,29 +126,11 @@ impl Text {
         &self.env
     }
 
-    /// Update the environment
-    ///
-    /// Returns true when [`Text::prepare`] must be called (again).
-    /// Note that [`Text::prepare`] is not called automatically since it must
-    /// not be called before fonts are loaded.
-    pub fn update_env<F: FnOnce(&mut UpdateEnv)>(&mut self, f: F) -> bool {
+    /// Update the environment and prepare for drawing
+    pub fn update_env<F: FnOnce(&mut UpdateEnv)>(&mut self, f: F) {
         let mut update = UpdateEnv::new(&mut self.env);
         f(&mut update);
         let action = update.finish().max(self.action);
-        match action {
-            Action::None => (),
-            Action::Wrap => self.wrap_lines(),
-            Action::Shape | Action::Runs => return true,
-        }
-        self.action = Action::None;
-        false
-    }
-
-    /// Prepare
-    ///
-    /// Calculates glyph layouts for use.
-    pub fn prepare(&mut self) {
-        let action = self.action;
         if action == Action::None {
             return;
         }

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -35,8 +35,7 @@ impl Text {
         let mut line = LineAdder::new(self.text_len() / 16, self.env.halign, width_bound);
 
         for (run_index, run) in self.glyph_runs.iter().enumerate() {
-            let font = fonts.get(run.font_id);
-            let scale_font = font.into_scaled(run.font_scale);
+            let scale_font = fonts.get_scaled(run.font_id, run.font_scale);
 
             if !line.runs.is_empty() && !run.append_to_prev {
                 line.new_line(0.0);

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -35,7 +35,7 @@ impl Text {
         let mut line = LineAdder::new(self.text_len() / 16, self.env.halign, width_bound);
 
         for (run_index, run) in self.glyph_runs.iter().enumerate() {
-            let scale_font = fonts.get_scaled(run.font_id, run.font_scale);
+            let scale_font = fonts.get(run.font_id).scaled(run.font_scale);
 
             if !line.runs.is_empty() && !run.append_to_prev {
                 line.new_line(0.0);

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -18,7 +18,7 @@
 //! This module *does not* perform line-breaking, wrapping or text reversal.
 
 use crate::{fonts, prepared, FontId, Range, Vec2};
-use ab_glyph::{Font, GlyphId, PxScale, ScaleFont};
+use ab_glyph::{GlyphId, PxScale};
 use smallvec::SmallVec;
 
 /// A positioned glyph
@@ -72,20 +72,119 @@ pub(crate) fn shape(
     text: &str,
     run: &prepared::Run,
 ) -> GlyphRun {
-    let scale_font = fonts().get_scaled(font_id, font_scale);
+    let mut glyphs = vec![];
+    let mut breaks = Default::default();
+    let mut end_no_space = 0.0;
+    let mut caret = 0.0;
 
-    if !(scale_font.scale().x >= 0.0 || scale_font.scale().y >= 0.0) {
-        return GlyphRun {
-            glyphs: vec![],
-            breaks: Default::default(),
-            font_id,
-            font_scale,
-            end_no_space: 0.0,
-            caret: 0.0,
-            range: run.range,
-            append_to_prev: run.append_to_prev(),
-        };
+    if font_scale.x >= 0.0 || font_scale.y >= 0.0 {
+        #[cfg(feature = "harfbuzz_rs")]
+        let r = shape_harfbuzz(font_id, font_scale, text, run);
+
+        #[cfg(not(feature = "harfbuzz_rs"))]
+        let r = shape_simple(font_id, font_scale, text, run);
+
+        glyphs = r.0;
+        breaks = r.1;
+        end_no_space = r.2;
+        caret = r.3;
     }
+
+    GlyphRun {
+        glyphs,
+        breaks,
+        font_id,
+        font_scale,
+        end_no_space,
+        caret,
+        range: run.range,
+        append_to_prev: run.append_to_prev(),
+    }
+}
+
+// Use HarfBuzz lib
+#[cfg(feature = "harfbuzz_rs")]
+fn shape_harfbuzz(
+    font_id: FontId,
+    font_scale: PxScale,
+    text: &str,
+    run: &prepared::Run,
+) -> (Vec<Glyph>, SmallVec<[GlyphBreak; 2]>, f32, f32) {
+    let font = fonts().get_harfbuzz(font_id, font_scale);
+
+    let slice = &text[run.range];
+    let idx_offset = run.range.start;
+
+    // TODO: cache the buffer for reuse later?
+    let buffer = harfbuzz_rs::UnicodeBuffer::new().add_str(slice);
+    let features = [];
+
+    let output = harfbuzz_rs::shape(&font, buffer, &features);
+
+    fn unit(x: harfbuzz_rs::Position) -> f32 {
+        // TODO: is this right?
+        x as f32 * (1.0 / 128.0)
+    }
+
+    let mut caret = 0.0;
+    let mut end_no_space = caret;
+
+    let mut breaks_iter = run.breaks.iter();
+    let mut next_break = breaks_iter.next().cloned().unwrap_or(u32::MAX);
+    assert!(next_break >= idx_offset);
+    let mut breaks = SmallVec::<[GlyphBreak; 2]>::with_capacity(run.breaks.len());
+
+    let mut glyphs = Vec::with_capacity(output.len());
+
+    for (info, pos) in output
+        .get_glyph_infos()
+        .iter()
+        .zip(output.get_glyph_positions().iter())
+    {
+        let index = idx_offset + info.cluster;
+        assert!(info.codepoint <= u16::MAX as u32, "failed to map glyph id");
+        let id = GlyphId(info.codepoint as u16);
+
+        if index == next_break {
+            let pos = glyphs.len() as u32;
+            breaks.push(GlyphBreak { pos, end_no_space });
+            next_break = breaks_iter.next().cloned().unwrap_or(u32::MAX);
+        }
+
+        let position = Vec2(caret + unit(pos.x_offset), unit(pos.y_offset));
+        glyphs.push(Glyph {
+            index,
+            id,
+            position,
+        });
+
+        // IIRC this is only applicable to vertical text, which we don't
+        // currently support:
+        debug_assert_eq!(pos.y_advance, 0);
+        caret += unit(pos.x_advance);
+        if text[(index as usize)..]
+            .chars()
+            .next()
+            .map(|c| !c.is_whitespace())
+            .unwrap()
+        {
+            end_no_space = caret;
+        }
+    }
+
+    (glyphs, breaks, end_no_space, caret)
+}
+
+// Simple implementation (kerning but no shaping)
+#[cfg(not(feature = "harfbuzz_rs"))]
+fn shape_simple(
+    font_id: FontId,
+    font_scale: PxScale,
+    text: &str,
+    run: &prepared::Run,
+) -> (Vec<Glyph>, SmallVec<[GlyphBreak; 2]>, f32, f32) {
+    use ab_glyph::{Font, ScaleFont};
+    let scale_font = fonts().get_scaled(font_id, font_scale);
 
     let slice = &text[run.range];
     let idx_offset = run.range.start;
@@ -97,7 +196,7 @@ pub(crate) fn shape(
     let mut breaks_iter = run.breaks.iter();
     let mut next_break = breaks_iter.next().cloned().unwrap_or(u32::MAX);
     assert!(next_break >= idx_offset);
-    let mut breaks = SmallVec::<[GlyphBreak; 2]>::new();
+    let mut breaks = SmallVec::<[GlyphBreak; 2]>::with_capacity(run.breaks.len());
 
     // Allocate with an over-estimate and shrink later:
     let mut glyphs = Vec::with_capacity(slice.len());
@@ -133,14 +232,5 @@ pub(crate) fn shape(
 
     glyphs.shrink_to_fit();
 
-    GlyphRun {
-        glyphs,
-        breaks,
-        font_id,
-        font_scale,
-        end_no_space,
-        caret,
-        range: run.range,
-        append_to_prev: run.append_to_prev(),
-    }
+    (glyphs, breaks, end_no_space, caret)
 }

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -72,7 +72,7 @@ pub(crate) fn shape(
     text: &str,
     run: &prepared::Run,
 ) -> GlyphRun {
-    let scale_font = fonts().get(font_id).into_scaled(font_scale);
+    let scale_font = fonts().get_scaled(font_id, font_scale);
 
     if !(scale_font.scale().x >= 0.0 || scale_font.scale().y >= 0.0) {
         return GlyphRun {

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -18,7 +18,7 @@
 //! This module *does not* perform line-breaking, wrapping or text reversal.
 
 use crate::{fonts, prepared, FontId, Range, Vec2};
-use ab_glyph::{Font, GlyphId};
+use ab_glyph::GlyphId;
 use smallvec::SmallVec;
 
 /// A positioned glyph
@@ -75,9 +75,7 @@ pub(crate) fn shape(font_id: FontId, dpem: f32, text: &str, run: &prepared::Run)
     let mut caret = 0.0;
 
     let font = fonts().get(font_id);
-    // TODO (requires ab_glyph 0.2.5): let upem = font.units_per_em().unwrap();
-    let upem = 2048.0;
-    let font_scale = dpem / upem * font.height_unscaled();
+    let font_scale = font.font_scale(dpem);
 
     if dpem >= 0.0 {
         #[cfg(feature = "harfbuzz_rs")]
@@ -185,14 +183,14 @@ fn shape_harfbuzz(
 
 // Simple implementation (kerning but no shaping)
 #[cfg(not(feature = "harfbuzz_rs"))]
-fn shape_simple<F: Font>(
-    font: F,
+fn shape_simple(
+    font: crate::Font,
     font_scale: f32,
     text: &str,
     run: &prepared::Run,
 ) -> (Vec<Glyph>, SmallVec<[GlyphBreak; 2]>, f32, f32) {
-    use ab_glyph::ScaleFont;
-    let scale_font = font.into_scaled(font_scale);
+    use ab_glyph::{Font, ScaleFont};
+    let scale_font = font.scaled(font_scale);
 
     let slice = &text[run.range];
     let idx_offset = run.range.start;


### PR DESCRIPTION
@RazrFalcon @alexheretic I wonder if you could help me with this?

This code *partly* works (using glyph-brush to do the drawing). It does do shaping and lay out a line of text which seems okay (though I haven't implemented BIDI yet).

Questions:

- [x] Font data management: I store a `Face` and create a `Font` on each use, since I only know the size at time of usage. Seems to work; I don't know whether there will be perf. issues later.
- Font scale conversion: HarfBuzz uses PPEM (pixels per font EM); ab-glyph doesn't specify. A direct conversion seems to work.
- Glyph position conversion: glyph-brush uses pixels in `f32`; HarfBuzz uses `u32` (couldn't find the unit): dividing by 128 seems to work (or may be a little dense); dividing by 100 was a bit too spaced out.
- [x] HarfBuzz apparently doesn't report the text index of each glyph? My code needs this (for anything related to navigation and line-wrapping). Any ideas? Apparently the "cluster" value is related to how many code-points comprise a glyph...