### PR TITLE
Implement RTL and BIDI text support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ lazy_static = "1.4.0"
 smallvec = "1.4.1"
 xi-unicode = "0.2.1"
 unicode-bidi = "0.3.4"
+unicode-bidi-mirroring = "0.1.0"
 
 [dependencies.harfbuzz_rs]
 version = "1.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 shaping = ["harfbuzz_rs"]
 
 [dependencies]
-ab_glyph = "0.2.2"
+ab_glyph = "0.2.5"
 font-kit = "0.8.0"
 lazy_static = "1.4.0"
 smallvec = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ font-kit = "0.8.0"
 lazy_static = "1.4.0"
 smallvec = "1.4.1"
 xi-unicode = "0.2.1"
+unicode-bidi = "0.3.4"
 
 [dependencies.harfbuzz_rs]
 version = "1.1.2"

--- a/src/env.rs
+++ b/src/env.rs
@@ -43,6 +43,18 @@ pub struct Environment {
     /// and vice-versa, however the default alignment direction can affect the
     /// layout of complex texts.
     pub dir: Direction,
+    /// Bidirectional text
+    ///
+    /// If enabled, right-to-left text embedded within left-to-right text and
+    /// RTL within LTR will be re-ordered correctly (up to the maximum embedding
+    /// level defined by Unicode Technical Report #9).
+    ///
+    /// If disabled, the base paragraph direction may be LTR or RTL depending on
+    /// [`Environment::dir`], but embedded text is not re-ordered.
+    ///
+    /// Normally this should be enabled, but within text-editors it might be
+    /// disabled (at user's preference).
+    pub bidi: bool,
     /// Horizontal alignment
     pub halign: Align,
     /// Vertical alignment
@@ -60,9 +72,10 @@ impl Default for Environment {
         Environment {
             dpp: 96.0 / 72.0,
             pt_size: 11.0,
-            dir: Direction::LR,
-            halign: Align::Default,
-            valign: Align::Default,
+            dir: Direction::default(),
+            bidi: true,
+            halign: Align::default(),
+            valign: Align::default(),
             wrap: true,
             bounds: Vec2::INFINITY,
         }
@@ -192,17 +205,19 @@ impl Default for Align {
 
 /// Directionality of environment
 ///
-/// TODO: support RL and possibly vertical directions.
+/// This can be used to force the text direction.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum Direction {
-    /// Left-to-Right (default)
+    /// Auto-detect (default)
+    Auto,
+    /// Left-to-Right
     LR,
-    // /// Right-to-Left
-    // RL,
+    /// Right-to-Left
+    RL,
 }
 
 impl Default for Direction {
     fn default() -> Self {
-        Direction::LR
+        Direction::Auto
     }
 }

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -50,8 +50,7 @@ impl Font {
     #[inline]
     pub(crate) fn font_scale(self, dpem: f32) -> f32 {
         use ab_glyph::Font;
-        // TODO (requires ab_glyph 0.2.5): let upem = font.units_per_em().unwrap();
-        let upem = 2048.0;
+        let upem = self.font.units_per_em().unwrap();
         dpem / upem * self.font.height_unscaled()
     }
 

--- a/src/prepared.rs
+++ b/src/prepared.rs
@@ -14,7 +14,7 @@ use crate::{Environment, UpdateEnv};
 
 mod text_runs;
 mod wrap_lines;
-pub(crate) use text_runs::Run;
+pub(crate) use text_runs::{LineRun, Run};
 use wrap_lines::{Line, RunPart};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
@@ -62,11 +62,16 @@ impl Action {
 #[derive(Clone, Debug, Default)]
 pub struct Text {
     env: Environment,
+    /// Contiguous text in logical order
     text: String,
+    /// Level runs within the text
     runs: SmallVec<[Run; 1]>,
+    /// Subsets of runs forming a line, with line direction
+    line_runs: SmallVec<[LineRun; 1]>,
     font_id: FontId,
     action: Action,
     required: Vec2,
+    /// Runs of glyphs (same order as `runs` sequence)
     glyph_runs: Vec<shaper::GlyphRun>,
     wrapped_runs: Vec<RunPart>,
     // Indexes of line-starts within wrapped_runs:

--- a/src/prepared/text_runs.rs
+++ b/src/prepared/text_runs.rs
@@ -12,9 +12,10 @@ use xi_unicode::LineBreakIterator;
 
 #[derive(Clone, Debug)]
 pub(crate) struct Run {
-    // TODO: support reversed texts
     /// Range in source text
     pub range: Range,
+    /// If true, run is right-to-left
+    pub rtl: bool,
     /// All soft-break locations within this range (excludes end)
     pub breaks: SmallVec<[u32; 5]>,
 }
@@ -45,6 +46,7 @@ impl Text {
 
         let mut start = 0;
         let mut breaks = Default::default();
+        let rtl = true; // FIXME
 
         for (pos, hard) in LineBreakIterator::new(&self.text) {
             if hard && start < pos {
@@ -53,7 +55,7 @@ impl Text {
                 range.start += start as u32;
                 range.end += start as u32;
 
-                self.runs.push(Run { range, breaks });
+                self.runs.push(Run { range, rtl, breaks });
                 start = pos;
                 breaks = Default::default();
             }
@@ -76,7 +78,7 @@ impl Text {
         {
             let range = (text_len..text_len).into();
             let breaks = Default::default();
-            self.runs.push(Run { range, breaks });
+            self.runs.push(Run { range, rtl, breaks });
         }
 
         assert_eq!(start, self.text.len()); // iterator always generates a break at the end

--- a/src/prepared/text_runs.rs
+++ b/src/prepared/text_runs.rs
@@ -44,8 +44,6 @@ impl Text {
     /// result of splitting and reversing according to Unicode TR9 aka
     /// Bidirectional algorithm), plus a list of "soft break" positions
     /// (where wrapping may introduce new lines depending on available space).
-    ///
-    /// TODO: implement BIDI processing
     pub(crate) fn prepare_runs(&mut self) {
         self.runs.clear();
         self.line_runs.clear();
@@ -137,6 +135,19 @@ impl Text {
             let rtl = self.runs[line_start].level.is_rtl();
             self.line_runs.push(LineRun { range, rtl });
         }
+
+        /*
+        println!("text: {}", &self.text);
+        for line in self.line_runs.iter() {
+            println!("line (rtl={}) runs:", line.rtl);
+            for run in &self.runs[line.range.to_std()] {
+                println!(
+                    "{:?}, text[{}..{}]: '{}', breaks={:?}",
+                    run.level, run.range.start, run.range.end, &self.text[run.range], run.breaks
+                );
+            }
+        }
+        */
     }
 }
 

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -60,15 +60,6 @@ impl LineAdder {
             self.new_line(0.0);
         }
 
-        // In LTR mode, caret.0 starts at 0, however it needs offsetting to
-        // account for the glyph's origin.
-        if self.line_is_empty() {
-            // We offset the caret horizontally based on the first glyph of the line
-            if let Some(glyph) = run.glyphs.iter().as_ref().first() {
-                self.caret.0 += scale_font.h_side_bearing(glyph.id);
-            }
-        }
-
         let mut line_len = self.caret.0 + run.end_no_space;
         if !self.justify && line_len <= self.width_bound {
             // Short-cut: we can add the entire run.
@@ -131,8 +122,7 @@ impl LineAdder {
                 if line_break {
                     // Offset new line since we are not at the start of the run
                     let glyph = run.glyphs[glyph_end as usize];
-                    let x = scale_font.h_side_bearing(glyph.id) - glyph.position.0;
-                    self.new_line(x);
+                    self.new_line(-glyph.position.0);
                 }
             }
         }

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -56,7 +56,7 @@ impl LineAdder {
     fn add_ltr(&mut self, fonts: &FontLibrary, run_index: usize, run: &GlyphRun, append: bool) {
         let scale_font = fonts.get(run.font_id).scaled(run.font_scale);
 
-        if !self.line_is_empty() && (!append || self.line_is_rtl) {
+        if !append || self.line_is_rtl {
             self.new_line(0.0);
         }
 
@@ -140,7 +140,7 @@ impl LineAdder {
     fn add_rtl(&mut self, fonts: &FontLibrary, run_index: usize, run: &GlyphRun, append: bool) {
         let scale_font = fonts.get(run.font_id).scaled(run.font_scale);
 
-        if !self.line_is_empty() && (!append || !self.line_is_rtl) {
+        if !append || !self.line_is_rtl {
             self.new_line(0.0);
         }
 
@@ -279,6 +279,7 @@ impl LineAdder {
         rtl: bool,
         run: &GlyphRun,
     ) {
+        // FIXME: we may not have the full range
         let mut text_range = run.range;
         if let Some(range) = self.text_range {
             text_range.start = range.start;
@@ -366,7 +367,7 @@ impl LineAdder {
         self.caret.1 -= self.descent;
         self.longest = self.longest.max(self.line_len);
         self.lines.push(Line {
-            text_range: self.text_range.unwrap(),
+            text_range: self.text_range.unwrap_or(Range::from(0u32..0)), // FIXME
             run_range: (self.line_start..self.runs.len()).into(),
             top,
             bottom: self.caret.1,

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -77,7 +77,7 @@ impl LineAdder {
             self.caret.0 += run.caret;
         } else {
             // We cannot fit the whole run on one line.
-            if run.rtl {
+            if run.level.is_rtl() {
                 // It makes no sense to wrap a run with the wrong direction.
                 self.add_rtl(fonts, run_index, run, false);
             }
@@ -160,7 +160,7 @@ impl LineAdder {
             self.add_part(&scale_font, run_index, 0..glyph_end, line_len, &run);
         } else {
             // We cannot fit the whole run on one line.
-            if !run.rtl {
+            if run.level.is_ltr() {
                 // It makes no sense to wrap a run with the wrong direction.
                 self.add_ltr(fonts, run_index, run, false);
             }
@@ -277,7 +277,7 @@ impl LineAdder {
         self.text_range = Some(text_range);
 
         if self.line_is_empty() {
-            self.line_is_rtl = run.rtl;
+            self.line_is_rtl = run.level.is_rtl();
         }
 
         // Adjust vertical position if necessary

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -232,6 +232,8 @@ fn shape_simple(
     run: &prepared::Run,
 ) -> (Vec<Glyph>, SmallVec<[GlyphBreak; 2]>, f32, f32) {
     use ab_glyph::Font;
+    use unicode_bidi_mirroring::get_mirrored;
+
     let scale_font = font.scaled(font_scale);
 
     let slice = &text[run.range];
@@ -258,8 +260,13 @@ fn shape_simple(
         false => iter.next(),
         true => iter.next_back(),
     };
-    while let Some((index, c)) = next_char_index() {
+    while let Some((index, mut c)) = next_char_index() {
         let index = idx_offset + index as u32;
+        if rtl {
+            if let Some(m) = get_mirrored(c) {
+                c = m;
+            }
+        }
         let id = scale_font.font().glyph_id(c);
 
         if index == next_break {

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -62,8 +62,6 @@ pub struct GlyphRun {
     pub range: Range,
     /// If true, text direction is right-to-left
     pub rtl: bool,
-    /// If true, append to the prior line (if any)
-    pub append_to_prev: bool,
 }
 
 /// Shape a `run` of text
@@ -132,7 +130,6 @@ pub(crate) fn shape(font_id: FontId, dpem: f32, text: &str, run: &prepared::Run)
         caret,
         range: run.range,
         rtl: run.rtl,
-        append_to_prev: run.append_to_prev(),
     }
 }
 

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -57,6 +57,8 @@ pub struct GlyphRun {
 
     /// Range of slice represented
     pub range: Range,
+    /// If true, text direction is right-to-left
+    pub rtl: bool,
     /// If true, append to the prior line (if any)
     pub append_to_prev: bool,
 }
@@ -98,6 +100,7 @@ pub(crate) fn shape(font_id: FontId, dpem: f32, text: &str, run: &prepared::Run)
         end_no_space,
         caret,
         range: run.range,
+        rtl: run.rtl,
         append_to_prev: run.append_to_prev(),
     }
 }

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -20,6 +20,7 @@
 use crate::{fonts, prepared, FontId, Range, Vec2};
 use ab_glyph::{GlyphId, ScaleFont};
 use smallvec::SmallVec;
+use unicode_bidi::Level;
 
 /// A positioned glyph
 #[derive(Clone, Copy, Debug)]
@@ -60,8 +61,8 @@ pub struct GlyphRun {
 
     /// Range of slice represented
     pub range: Range,
-    /// If true, text direction is right-to-left
-    pub rtl: bool,
+    /// BIDI level (odd levels are right-to-left)
+    pub level: Level,
 }
 
 /// Shape a `run` of text
@@ -93,8 +94,7 @@ pub(crate) fn shape(font_id: FontId, dpem: f32, text: &str, run: &prepared::Run)
         caret = r.3;
     }
 
-    let rtl = run.level.is_rtl();
-    if rtl {
+    if run.level.is_rtl() {
         // With RTL text, end_no_space means start_no_space; recalculate
         let mut break_i = breaks.len().wrapping_sub(1);
         let mut start_no_space = caret;
@@ -130,7 +130,7 @@ pub(crate) fn shape(font_id: FontId, dpem: f32, text: &str, run: &prepared::Run)
         end_no_space,
         caret,
         range: run.range,
-        rtl,
+        level: run.level,
     }
 }
 


### PR DESCRIPTION
This adds support for:

- shaping right-to-left text (doesn't actually require re-ordering since we just read the text backwards),
- line-wrapping right-to-left text (harder than expected),
- splitting runs when the BIDI embedding level changes,
- and glyph-mirroring.

As such, it can now display simple bidirectional text.

Also, text navigation will need many fixes. That will be another PR.