### PR TITLE
Fix crash with empty RTL run

### DIFF
--- a/src/prepared/glyph_pos.rs
+++ b/src/prepared/glyph_pos.rs
@@ -141,14 +141,16 @@ impl Text {
 
             // If index is at the end of a run, we potentially get two matches.
             if index == run_part.text_end as usize {
-                let pos = if glyph_run.level.is_ltr() {
-                    if run_part.glyph_range.end() < glyph_run.glyphs.len() {
-                        glyph_run.glyphs[run_part.glyph_range.end()].position
-                    } else {
-                        Vec2(glyph_run.caret, 0.0)
-                    }
+                let i = if glyph_run.level.is_ltr() {
+                    run_part.glyph_range.end()
                 } else {
-                    glyph_run.glyphs[run_part.glyph_range.start()].position
+                    run_part.glyph_range.start()
+                };
+                let pos = if i < glyph_run.glyphs.len() {
+                    glyph_run.glyphs[i].position
+                } else {
+                    // NOTE: for RTL we only hit this case if glyphs.len() == 0
+                    Vec2(glyph_run.caret, 0.0)
                 };
 
                 let pos = run_part.offset + pos;

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -60,7 +60,7 @@ impl LineAdder {
     fn add_ltr(&mut self, fonts: &FontLibrary, run_index: usize, run: &GlyphRun, append: bool) {
         let scale_font = fonts.get(run.font_id).scaled(run.font_scale);
 
-        if !append || self.line_is_rtl {
+        if !append || self.line_is_rtl == Some(true) {
             self.new_line(run.range.start, 0.0);
         }
 
@@ -176,7 +176,7 @@ impl LineAdder {
     fn add_rtl(&mut self, fonts: &FontLibrary, run_index: usize, run: &GlyphRun, append: bool) {
         let scale_font = fonts.get(run.font_id).scaled(run.font_scale);
 
-        if !append || !self.line_is_rtl {
+        if !append || self.line_is_rtl == Some(false) {
             self.new_line(run.range.start, 0.0);
         }
 
@@ -220,7 +220,7 @@ impl LineAdder {
                     0..glyph_end,
                 );
             } else {
-                return self.add_ltr(fonts, run_index, run, false);
+                self.add_ltr(fonts, run_index, run, false);
             }
         } else {
             // We perform line-wrapping on this run.
@@ -315,7 +315,7 @@ struct LineAdder {
     halign: Align,
     justify: bool,
     wrap: bool,
-    line_is_rtl: bool,
+    line_is_rtl: Option<bool>,
     width_bound: f32,
 }
 impl LineAdder {
@@ -334,9 +334,7 @@ impl LineAdder {
 
     /// Does the current line have any content?
     fn line_is_empty(&self) -> bool {
-        self.runs[self.line_start..]
-            .iter()
-            .all(|run| run.glyph_range.len() == 0)
+        self.line_is_rtl.is_none()
     }
 
     fn add_part<F: Font, SF: ScaleFont<F>>(
@@ -350,8 +348,8 @@ impl LineAdder {
         run_index: usize,
         glyph_range: std::ops::Range<u32>,
     ) {
-        if self.line_is_empty() {
-            self.line_is_rtl = rtl;
+        if self.line_is_rtl.is_none() && glyph_range.start < glyph_range.end {
+            self.line_is_rtl = Some(rtl);
         }
 
         // Adjust vertical position if necessary
@@ -389,6 +387,7 @@ impl LineAdder {
 
     fn finish_line(&mut self, text_index: u32) {
         let num_runs = self.runs.len() - self.line_start;
+        let rtl = self.line_is_rtl == Some(true);
 
         // Unic TR#9 L2: reverse items on the line
         // This implementation does not correspond directly to the Unicode
@@ -408,10 +407,7 @@ impl LineAdder {
                 slice[len1].0 = a;
                 slice = &mut slice[1..len1];
             };
-            let line_level = match self.line_is_rtl {
-                false => Level::ltr(),
-                true => Level::rtl(),
-            };
+            let line_level = if rtl { Level::rtl() } else { Level::ltr() };
             while level > line_level {
                 let mut start = None;
                 for i in 0..num_runs {
@@ -453,22 +449,22 @@ impl LineAdder {
             let runs = &mut self.runs[self.line_start..];
 
             let offset = match self.halign {
-                Align::Default => match self.line_is_rtl {
+                Align::Default => match rtl {
                     false => 0.0,
                     true => self.width_bound,
                 },
-                Align::TL => match self.line_is_rtl {
+                Align::TL => match rtl {
                     false => 0.0,
                     true => self.line_len,
                 },
                 Align::Centre => {
                     let mut offset = 0.5 * (self.width_bound - self.line_len);
-                    if self.line_is_rtl {
+                    if rtl {
                         offset += self.line_len;
                     }
                     offset
                 }
-                Align::BR => match self.line_is_rtl {
+                Align::BR => match rtl {
                     false => self.width_bound - self.line_len,
                     true => self.width_bound,
                 },
@@ -478,7 +474,7 @@ impl LineAdder {
                     let num_gaps = (num_runs - 1) as f32;
                     let per_gap = (self.width_bound - self.line_len) / num_gaps;
 
-                    if !self.line_is_rtl {
+                    if !rtl {
                         let mut offset = per_gap;
                         for run in &mut runs[1..] {
                             run.offset.0 += offset;
@@ -528,6 +524,7 @@ impl LineAdder {
         self.ascent = 0.0;
         self.descent = 0.0;
         self.line_gap = 0.0;
+        self.line_is_rtl = None;
     }
 
     // Returns: required dimensions


### PR DESCRIPTION
This fixes a crash on an empty RTL line due to wrapping. Unfortunately this empty line can be generated erroneously resulting in a spurious extra line between wrapped RTL text and wrapped LTR text — fix is on-going.