### PR TITLE
Correct wrapping behaviour for bidi parts not following line direction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ smallvec = "1.4.1"
 xi-unicode = "0.2.1"
 unicode-bidi = "0.3.4"
 unicode-bidi-mirroring = "0.1.0"
+thiserror = "1.0.20"
 
 [dependencies.harfbuzz_rs]
 version = "1.1.2"


### PR DESCRIPTION
Allows correct wrapping of LTR text on an RTL line and vice-versa.