### PR TITLE
Wrap lines rewrite

### DIFF
--- a/src/prepared.rs
+++ b/src/prepared.rs
@@ -474,7 +474,7 @@ impl Text {
         if line >= self.lines.len() {
             return None;
         }
-        let line = self.lines[line];
+        let line = &self.lines[line];
         let run_range = line.run_range.to_std();
 
         let mut best = line.text_range.start;

--- a/src/prepared/glyph_pos.rs
+++ b/src/prepared/glyph_pos.rs
@@ -183,7 +183,6 @@ impl Text {
             break;
         }
 
-        println!("text_glyph_pos: {:?}", v);
         MarkerPosIter { v, a, b }
     }
 

--- a/src/prepared/glyph_pos.rs
+++ b/src/prepared/glyph_pos.rs
@@ -10,7 +10,7 @@ use crate::{fonts, Vec2};
 use ab_glyph::ScaleFont;
 
 /// Used to return the position of a glyph with associated metrics
-#[derive(Copy, Clone, Default, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct MarkerPos {
     /// (x, y) coordinate of glyph
     pub pos: Vec2,
@@ -183,6 +183,7 @@ impl Text {
             break;
         }
 
+        println!("text_glyph_pos: {:?}", v);
         MarkerPosIter { v, a, b }
     }
 

--- a/src/prepared/text_runs.rs
+++ b/src/prepared/text_runs.rs
@@ -155,18 +155,17 @@ impl Text {
             }
         }
 
-        /*
         println!("text: {}", &self.text);
         for line in self.line_runs.iter() {
             println!("line (rtl={}) runs:", line.rtl);
             for run in &self.runs[line.range.to_std()] {
+                let slice = &self.text[run.range];
                 println!(
-                    "{:?}, text[{}..{}]: '{}', breaks={:?}",
-                    run.level, run.range.start, run.range.end, &self.text[run.range], run.breaks
+                    "{:?}, text[{}..{}]: '{}', breaks={:?}, no_break={}",
+                    run.level, run.range.start, run.range.end, slice, run.breaks, run.no_break,
                 );
             }
         }
-        */
     }
 }
 

--- a/src/prepared/text_runs.rs
+++ b/src/prepared/text_runs.rs
@@ -18,7 +18,9 @@ pub(crate) struct Run {
     /// BIDI level
     pub level: Level,
     /// All soft-break locations within this range (excludes end)
-    // TODO: replace this with more `Run` instances?
+    ///
+    /// Note: it would be equivalent to use a separate `Run` for each sub-range
+    /// in the text instead of tracking breaks via this field.
     pub breaks: SmallVec<[u32; 5]>,
     /// If true, the logical-end of this Run is not a valid break point
     pub no_break: bool,

--- a/src/prepared/text_runs.rs
+++ b/src/prepared/text_runs.rs
@@ -155,6 +155,7 @@ impl Text {
             }
         }
 
+        /*
         println!("text: {}", &self.text);
         for line in self.line_runs.iter() {
             println!("line (rtl={}) runs:", line.rtl);
@@ -166,6 +167,7 @@ impl Text {
                 );
             }
         }
+        */
     }
 }
 

--- a/src/prepared/text_runs.rs
+++ b/src/prepared/text_runs.rs
@@ -20,7 +20,7 @@ pub(crate) struct Run {
     /// All soft-break locations within this range (excludes end)
     // TODO: replace this with more `Run` instances?
     pub breaks: SmallVec<[u32; 5]>,
-    /// If true, the logical-start of this Run is not a valid break point
+    /// If true, the logical-end of this Run is not a valid break point
     pub no_break: bool,
 }
 
@@ -75,7 +75,6 @@ impl Text {
         let mut next_break = breaks_iter.next().unwrap_or((0, false));
 
         let mut line_start = 0;
-        let mut no_break = false;
 
         for pos in 1..self.text.len() {
             let is_break = next_break.0 == pos;
@@ -90,9 +89,8 @@ impl Text {
                     range,
                     level,
                     breaks,
-                    no_break,
+                    no_break: !is_break,
                 });
-                no_break = !is_break;
 
                 if hard_break {
                     let range = Range::from(line_start..self.runs.len());
@@ -126,7 +124,7 @@ impl Text {
             range,
             level,
             breaks,
-            no_break,
+            no_break: false,
         });
         if line_start < self.runs.len() {
             let range = Range::from(line_start..self.runs.len());

--- a/src/prepared/text_runs.rs
+++ b/src/prepared/text_runs.rs
@@ -18,7 +18,10 @@ pub(crate) struct Run {
     /// BIDI level
     pub level: Level,
     /// All soft-break locations within this range (excludes end)
+    // TODO: replace this with more `Run` instances?
     pub breaks: SmallVec<[u32; 5]>,
+    /// If true, the logical-start of this Run is not a valid break point
+    pub no_break: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -72,6 +75,7 @@ impl Text {
         let mut next_break = breaks_iter.next().unwrap_or((0, false));
 
         let mut line_start = 0;
+        let mut no_break = false;
 
         for pos in 1..self.text.len() {
             let is_break = next_break.0 == pos;
@@ -86,7 +90,9 @@ impl Text {
                     range,
                     level,
                     breaks,
+                    no_break,
                 });
+                no_break = !is_break;
 
                 if hard_break {
                     let range = Range::from(line_start..self.runs.len());
@@ -120,6 +126,7 @@ impl Text {
             range,
             level,
             breaks,
+            no_break,
         });
         if line_start < self.runs.len() {
             let range = Range::from(line_start..self.runs.len());
@@ -141,6 +148,7 @@ impl Text {
                     range,
                     level,
                     breaks,
+                    no_break: false,
                 });
 
                 let range = Range::from(line_start..self.runs.len());

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -126,11 +126,14 @@ impl LineAdder {
                         part_len = line_len - self.line_len;
                     }
                     self.line_len = line_len;
-                    let text_end = run
-                        .glyphs
-                        .get(glyph_end as usize)
-                        .map(|g| g.index)
-                        .unwrap_or(run.range.end);
+                    let mut text_end = run.range.end;
+                    let mut end_glyph = glyph_end;
+                    if (end_glyph as usize) < run.glyphs.len() {
+                        // In this case we are wrapping; to prevent a location
+                        // from occurring on two lines, we go back one glyph.
+                        end_glyph -= 1;
+                        text_end = run.glyphs[end_glyph as usize].index;
+                    }
                     self.add_part(
                         &scale_font,
                         xoffset,
@@ -139,7 +142,7 @@ impl LineAdder {
                         &run,
                         text_end,
                         run_index,
-                        glyph_start..glyph_end,
+                        glyph_start..end_glyph,
                     );
                 }
 
@@ -231,9 +234,13 @@ impl LineAdder {
                         part_len = line_len - self.line_len;
                     }
                     self.line_len = line_len;
+                    let mut start_glyph = glyph_start;
                     let mut text_end = run.range.end;
-                    if glyph_start > 0 {
-                        text_end = run.glyphs[glyph_start as usize - 1].index;
+                    if start_glyph > 0 {
+                        // In this case we are wrapping; to prevent a location
+                        // from occurring on two lines, we go back one glyph.
+                        text_end = run.glyphs[start_glyph as usize].index;
+                        start_glyph += 1;
                     }
                     self.add_part(
                         &scale_font,
@@ -243,7 +250,7 @@ impl LineAdder {
                         &run,
                         text_end,
                         run_index,
-                        glyph_start..glyph_end,
+                        start_glyph..glyph_end,
                     );
                 }
 

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -303,6 +303,11 @@ impl LineAdder {
         }
         let line_len = caret; // we already excluded whitespace from last part's length
 
+        // Other parts of this library expect runs to be in logical order, so
+        // we re-order now (does not affect display position).
+        // TODO: should we change this, e.g. for visual-order navigation?
+        self.runs[line_start..].sort_by_key(|run| run.text_end);
+
         // Apply alignment
         {
             let num_runs = self.runs.len() - line_start;

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -36,19 +36,18 @@ impl Text {
         // Almost everything in "this" method depends on the line direction, so
         // we determine that then call the appropriate implementation.
         for line in self.line_runs.iter() {
-            let mut first_line = true;
+            // Each LineRun contains at least one Run, though a Run may be empty
+            debug_assert!(line.range.start < line.range.end);
             let mut index = line.range.start();
+            adder.new_line(self.glyph_runs[index].range.start);
+            adder.line_is_rtl = line.rtl;
+
             while index < line.range.end() {
                 let run = &self.glyph_runs[index];
-                if first_line {
-                    adder.new_line(run.range.start);
-                    adder.line_is_rtl = line.rtl;
-                }
                 match line.rtl {
                     false => adder.add_ltr(&fonts, index, run),
                     true => adder.add_rtl(&fonts, index, run),
                 }
-                first_line = false;
                 index += 1;
             }
         }

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -48,7 +48,6 @@ impl Text {
 
         // Almost everything in "this" method depends on the line direction, so
         // we determine that then call the appropriate implementation.
-        println!("have {} lines", self.line_runs.len());
         for line in self.line_runs.iter() {
             // Each LineRun contains at least one Run, though a Run may be empty
             let end_index = line.range.end();
@@ -58,10 +57,6 @@ impl Text {
                 false => Level::ltr(),
                 true => Level::rtl(),
             };
-            println!(
-                "line [rtl={}] has runs {}..{}",
-                line.rtl, line.range.start, end_index
-            );
 
             // Tuples: (index, part)
             let mut start = (line.range.start(), 0, 0);
@@ -75,8 +70,6 @@ impl Text {
             'a: while index < end_index {
                 let run = &self.glyph_runs[index];
                 let num_parts = run.num_parts();
-                println!("run {} has {} parts", index, run.num_parts());
-                println!("start={:?}, end={:?}", start, end);
                 let allow_break = !run.no_break; // break allowed at end of run
 
                 let mut last_part = start.1;
@@ -86,7 +79,6 @@ impl Text {
                         run.part_lengths(last_part..part);
                     let line_len = caret + part_len_no_space;
                     if line_len > width_bound && end.2 > 0 {
-                        println!("add_line — wrapping — start={:?}, end={:?}", start, end);
                         // Add up to last valid break point then wrap and reset
                         let slice = &mut parts[0..end.2];
                         adder.add_line(fonts, level, end_len, &self.glyph_runs, slice);
@@ -134,11 +126,9 @@ impl Text {
             if parts.len() > 0 {
                 // It should not be possible for a line to end with a no-break, so:
                 debug_assert_eq!(parts.len(), end.2);
-                println!("add_line — end-of-line — start={:?}, end={:?}", start, end);
                 adder.add_line(fonts, level, end_len, &self.glyph_runs, &mut parts);
             }
         }
-        println!();
 
         self.required = adder.finish(self.env.valign, self.env.bounds.1);
         self.wrapped_runs = adder.runs;
@@ -182,12 +172,10 @@ impl LineAdder {
         let line_is_rtl = line_level.is_rtl();
 
         // Iterate runs to determine max ascent, level, etc.
-        println!("add_line has parts:");
         let mut last_run = u32::MAX;
         let (mut ascent, mut descent, mut line_gap) = (0f32, 0f32, 0f32);
         let mut max_level = line_level;
         for part in parts.iter() {
-            println!("\t{:?}", part);
             if last_run == part.run {
                 continue;
             }
@@ -329,7 +317,6 @@ impl LineAdder {
                     is_gap.copy_within(1..len, 0);
                 }
 
-                println!("num gaps: {}", num_gaps);
                 per_gap = spare / (num_gaps as f32);
                 0.0
             }
@@ -380,11 +367,6 @@ impl LineAdder {
             top,
             bottom: self.vcaret,
         });
-
-        println!("line: {:?}", self.lines[self.lines.len() - 1]);
-        for run in &self.runs[line_start..] {
-            println!("run: {:?}", run);
-        }
     }
 
     // Returns: required dimensions

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -54,9 +54,9 @@ pub struct GlyphBreak {
 /// text, this is the end nearer the origin than `caret`).
 #[derive(Clone, Debug)]
 pub struct GlyphRun {
-    /// Sequence of all glyphs, with index in text
+    /// Sequence of all glyphs, in left-to-right order
     pub glyphs: Vec<Glyph>,
-    /// Sequence of all break points
+    /// Sequence of all break points, in left-to-right order
     pub breaks: SmallVec<[GlyphBreak; 2]>,
 
     pub font_id: FontId,
@@ -79,28 +79,109 @@ pub struct GlyphRun {
 }
 
 impl GlyphRun {
-    /// Starting offset of the run, excluding space
+    /// Number of parts
     ///
-    /// Note that runs never have space at the logical start, thus we only
-    /// need to save this value for the logical end of the run.
-    pub fn start_no_space(&self) -> f32 {
-        if self.level.is_ltr() {
-            0.0
-        } else {
-            self.no_space_end
-        }
+    /// Parts are in logical order
+    pub fn num_parts(&self) -> usize {
+        self.breaks.len() + 1
     }
 
-    /// Ending offset of the run, excluding space
+    /// Calculate lengths for a part range
     ///
-    /// Note that runs never have space at the logical start, thus we only
-    /// need to save this value for the logical end of the run.
-    pub fn end_no_space(&self) -> f32 {
+    /// Parts are identified in logical order with end index up to
+    /// `self.num_parts()`.
+    ///
+    /// Returns `(offset, len_no_space, len)` where `offset` is the distance to
+    /// from the origin to the start of the left-most part, `len` is the
+    /// horizontal length of the given parts, and `len_no_space` is `len` but
+    /// excluding whitespace at the logical end.
+    pub fn part_lengths(&self, range: std::ops::Range<usize>) -> (f32, f32, f32) {
+        // TODO: maybe we should adjust self.breaks to clean this up?
+        assert!(range.start <= range.end);
+
+        let (mut offset, mut len_no_space, mut len) = (0.0, 0.0, 0.0);
         if self.level.is_ltr() {
-            self.no_space_end
+            if range.end > 0 {
+                len_no_space = self.no_space_end;
+                len = self.caret;
+                if range.end <= self.breaks.len() {
+                    let b = self.breaks[range.end - 1];
+                    len_no_space = b.no_space_end;
+                    if (b.pos as usize) < self.glyphs.len() {
+                        len = self.glyphs[b.pos as usize].position.0
+                    }
+                }
+            }
+
+            if range.start > 0 {
+                let glyph = self.breaks[range.start - 1].pos as usize;
+                offset = self.glyphs[glyph].position.0;
+                len_no_space -= offset;
+                len -= offset;
+            }
         } else {
-            self.caret
+            if range.start <= self.breaks.len() {
+                len = self.caret;
+                if range.start > 0 {
+                    let b = self.breaks.len() - range.start;
+                    let pos = self.breaks[b].pos as usize;
+                    if pos < self.glyphs.len() {
+                        len = self.glyphs[pos].position.0;
+                        //                     let scale_font = fonts().get(self.font_id).scaled(self.font_scale);
+                        //                     len = g.position.0 + scale_font.h_advance(g.id);
+                    }
+                }
+                len_no_space = len;
+            }
+            if range.end <= self.breaks.len() {
+                offset = self.caret;
+                if range.end == 0 {
+                    len_no_space = 0.0;
+                } else {
+                    let b = self.breaks.len() - range.end;
+                    let b = self.breaks[b];
+                    len_no_space -= b.no_space_end;
+                    if (b.pos as usize) < self.glyphs.len() {
+                        offset = self.glyphs[b.pos as usize].position.0;
+                    }
+                }
+                len -= offset;
+            }
         }
+        (offset, len_no_space, len)
+    }
+
+    /// Get glyph index from part index
+    pub fn to_glyph_range(&self, range: std::ops::Range<usize>) -> Range {
+        let mut start = range.start;
+        let mut end = range.end;
+
+        let rtl = self.level.is_rtl();
+        if rtl {
+            let num_parts = self.num_parts();
+            start = num_parts - start;
+            end = num_parts - end;
+        }
+
+        let map = |part: usize| {
+            if part == 0 {
+                0
+            } else if part <= self.breaks.len() {
+                self.breaks[part - 1].pos as usize
+            } else {
+                debug_assert_eq!(part, self.breaks.len() + 1);
+                self.glyphs.len()
+            }
+        };
+
+        let mut start = map(start);
+        let mut end = map(end);
+
+        if rtl {
+            std::mem::swap(&mut start, &mut end);
+        }
+
+        Range::from(start..end)
     }
 }
 

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -69,10 +69,13 @@ pub struct GlyphRun {
     /// Position of next glyph, if this run is followed by another
     pub caret: f32,
 
+    // TODO: maybe we shouldn't duplicate this information?
     /// Range of text represented
     pub range: Range,
     /// BIDI level (odd levels are right-to-left)
     pub level: Level,
+    /// If true, the logical-start of this Run is not a valid break point
+    pub no_break: bool,
 }
 
 impl GlyphRun {
@@ -167,6 +170,7 @@ pub(crate) fn shape(font_id: FontId, dpem: f32, text: &str, run: &prepared::Run)
         caret,
         range: run.range,
         level: run.level,
+        no_break: run.no_break,
     }
 }
 


### PR DESCRIPTION
This is a re-write of most of the wrapping code — all because the previous code could not easily be adapted to respect a no-break-at-end-of-run flag. This flag is a little important for bidi and will be much more important once formatting is implemented (e.g. to prevent wrapping after a bold letter in the middle of a word).

The new code is shorter and much cleaner than the old code, and avoids another bug I found in the old code (to do with justified bidi text). I care not to compare performance, but it's likely similar.

Several TODO notes remain here; these are for consideration later (if they aren't acted on, that's also fine).