### PR TITLE
Basic Markdown parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ exclude = ["design"]
 # Enable shaping. Prefer to depend on "shaping" since we may replace harfbuzz_rs.
 shaping = ["harfbuzz_rs"]
 
+# Enable Markdown parsing
+markdown = ["pulldown-cmark"]
+
 [dependencies]
 ab_glyph = "0.2.5"
 font-kit = "0.8.0"
@@ -25,6 +28,7 @@ xi-unicode = "0.2.1"
 unicode-bidi = "0.3.4"
 unicode-bidi-mirroring = "0.1.0"
 thiserror = "1.0.20"
+pulldown-cmark = { version = "0.8.0", optional = true }
 
 [dependencies.harfbuzz_rs]
 version = "1.1.2"

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -172,6 +172,8 @@ impl FontLibrary {
 
     /// Load a default font
     ///
+    /// This *must* be called before any other font-loading method.
+    ///
     /// This should be at least once before attempting to query any font-derived
     /// properties (such as text dimensions).
     #[inline]

--- a/src/prepared/text_runs.rs
+++ b/src/prepared/text_runs.rs
@@ -128,22 +128,9 @@ impl Text {
             let hard_break = is_break && next_break.1;
             let bidi_break = bidi && levels[pos] != level;
 
-            let fmt_break = if let Some(fmt) = next_fmt {
-                if fmt.start as usize == pos {
-                    if let Some(id) = fmt.font_id {
-                        font_id = id;
-                    }
-                    if fmt.pt_size.is_finite() {
-                        dpem = fmt.pt_size * dpp;
-                    }
-                    next_fmt = fmt_iter.next();
-                    true
-                } else {
-                    false
-                }
-            } else {
-                false
-            };
+            let fmt_break = next_fmt
+                .map(|fmt| fmt.start as usize == pos)
+                .unwrap_or(false);
 
             if hard_break || bidi_break || fmt_break {
                 let mut range = trim_control(&self.text[start..pos]);
@@ -159,6 +146,18 @@ impl Text {
                     no_break: !is_break,
                     level,
                 });
+
+                if let Some(fmt) = next_fmt {
+                    if fmt.start as usize == pos {
+                        if let Some(id) = fmt.font_id {
+                            font_id = id;
+                        }
+                        if fmt.pt_size.is_finite() {
+                            dpem = fmt.pt_size * dpp;
+                        }
+                        next_fmt = fmt_iter.next();
+                    }
+                }
 
                 if hard_break {
                     let range = Range::from(line_start..self.runs.len());

--- a/src/rich.rs
+++ b/src/rich.rs
@@ -84,6 +84,18 @@ pub struct FormatList {
 }
 
 impl FormatList {
+    /// Append or replace last item
+    #[inline]
+    pub fn set_last(&mut self, item: FormatSpecifier) {
+        if let Some(last) = self.seq.last_mut() {
+            if last.start >= item.start {
+                *last = item;
+                return;
+            }
+        }
+        self.seq.push(item);
+    }
+
     /// True if the list empty
     #[inline]
     pub fn is_empty(&self) -> bool {
@@ -210,7 +222,7 @@ impl TryFrom<&[FormatSpecifier]> for FormatList {
 /// (at the start) from the environment.
 ///
 /// This type can be default-constructed, but the default instance does nothing.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FormatSpecifier {
     pub(crate) start: u32,              // index in text
     pub(crate) font_id: Option<FontId>, // if None, use previous/default value

--- a/src/rich.rs
+++ b/src/rich.rs
@@ -5,6 +5,9 @@
 
 //! Models of rich text in abstract from an environment
 
+#[cfg(feature = "markdown")]
+mod markdown;
+
 use crate::fonts::FontId;
 use std::convert::TryFrom;
 use thiserror::Error;
@@ -27,6 +30,13 @@ pub struct Text {
 }
 
 impl Text {
+    /// Parse input as Markdown
+    #[cfg(feature = "markdown")]
+    #[inline]
+    pub fn from_md(text: &str) -> Self {
+        markdown::parse(text)
+    }
+
     /// The length of all concatenated runs
     pub fn len(&self) -> usize {
         self.text.len()

--- a/src/rich/markdown.rs
+++ b/src/rich/markdown.rs
@@ -5,19 +5,52 @@
 
 //! KAS Rich-Text library — parsing
 
-use super::{Text, FormatList};
-use pulldown_cmark::{Event, Parser};
+use super::{FormatList, FormatSpecifier, Text};
+use crate::fonts::{fonts, FontSelector, Style, Weight};
+use pulldown_cmark::{Event, Parser, Tag};
 
+// TODO: error handling
+// TODO: reduce calls to load_font via caching?
 pub(crate) fn parse(input: &str) -> Text {
     let mut text = String::with_capacity(input.len());
     let mut formatting = FormatList::default();
-    
+
+    let fonts = fonts();
+
+    let mut stack = Vec::with_capacity(16);
+    let mut item = StackItem::default();
+    let mut first_para = true;
+
+    // This is really just to ensure load_default gets called first:
+    item.spec.font_id = Some(fonts.load_default().unwrap());
+
     // TODO: parser options — perhaps strikethrough?
     let mut parser = Parser::new(input);
-    while let Some(item) = parser.next() {
-        match item {
-            Event::Start(tag) => unimplemented!("{:?}", tag),
-            Event::End(tag) => unimplemented!("{:?}", tag),
+    while let Some(ev) = parser.next() {
+        dbg!(&ev);
+        match ev {
+            Event::Start(tag) => {
+                item.spec.start = text.len() as u32;
+                stack.push(item.clone());
+                if item.tag(tag) {
+                    if first_para {
+                        first_para = false;
+                    } else {
+                        text.push_str("\n\n");
+                    }
+                }
+                item.spec.font_id = Some(fonts.load_font(item.sel.clone()).unwrap());
+                dbg!(&item.spec);
+                formatting.set_last(item.spec);
+            }
+            Event::End(_) => {
+                if let Some(x) = stack.pop() {
+                    item = x;
+                    item.spec.start = text.len() as u32;
+                    dbg!(&item.spec);
+                    formatting.set_last(item.spec);
+                }
+            }
             Event::Text(part) => text.push_str(&part),
             Event::Code(part) => unimplemented!("{:?}", part),
             Event::Html(part) => unimplemented!("{:?}", part),
@@ -28,6 +61,25 @@ pub(crate) fn parse(input: &str) -> Text {
             Event::TaskListMarker(checked) => unimplemented!("{:?}", checked),
         }
     }
-    
+
     Text { text, formatting }
+}
+
+#[derive(Clone, Debug, Default)]
+struct StackItem {
+    sel: FontSelector,
+    spec: FormatSpecifier,
+}
+
+impl StackItem {
+    // process a tag; return true on paragraph
+    fn tag(&mut self, tag: Tag) -> bool {
+        match tag {
+            Tag::Paragraph => return true,
+            Tag::Emphasis => self.sel.set_style(Style::Italic),
+            Tag::Strong => self.sel.set_weight(Weight::BOLD),
+            tag @ _ => unimplemented!("{:?}", tag),
+        }
+        false
+    }
 }

--- a/src/rich/markdown.rs
+++ b/src/rich/markdown.rs
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! KAS Rich-Text library — parsing
+
+use super::{Text, FormatList};
+use pulldown_cmark::{Event, Parser};
+
+pub(crate) fn parse(input: &str) -> Text {
+    let mut text = String::with_capacity(input.len());
+    let mut formatting = FormatList::default();
+    
+    // TODO: parser options — perhaps strikethrough?
+    let mut parser = Parser::new(input);
+    while let Some(item) = parser.next() {
+        match item {
+            Event::Start(tag) => unimplemented!("{:?}", tag),
+            Event::End(tag) => unimplemented!("{:?}", tag),
+            Event::Text(part) => text.push_str(&part),
+            Event::Code(part) => unimplemented!("{:?}", part),
+            Event::Html(part) => unimplemented!("{:?}", part),
+            Event::FootnoteReference(part) => unimplemented!("{:?}", part),
+            Event::SoftBreak => (),
+            Event::HardBreak => (),
+            Event::Rule => unimplemented!(),
+            Event::TaskListMarker(checked) => unimplemented!("{:?}", checked),
+        }
+    }
+    
+    Text { text, formatting }
+}

--- a/src/rich/markdown.rs
+++ b/src/rich/markdown.rs
@@ -6,7 +6,7 @@
 //! KAS Rich-Text library — parsing
 
 use super::{FormatList, FormatSpecifier, Text};
-use crate::fonts::{fonts, FontSelector, Style, Weight};
+use crate::fonts::{fonts, FamilyName, FontSelector, Style, Weight};
 use pulldown_cmark::{Event, Parser, Tag};
 
 // TODO: error handling
@@ -17,9 +17,9 @@ pub(crate) fn parse(input: &str) -> Text {
 
     let fonts = fonts();
 
+    let mut line = Line::None;
     let mut stack = Vec::with_capacity(16);
     let mut item = StackItem::default();
-    let mut first_para = true;
 
     // This is really just to ensure load_default gets called first:
     item.spec.font_id = Some(fonts.load_default().unwrap());
@@ -27,32 +27,36 @@ pub(crate) fn parse(input: &str) -> Text {
     // TODO: parser options — perhaps strikethrough?
     let mut parser = Parser::new(input);
     while let Some(ev) = parser.next() {
-        dbg!(&ev);
         match ev {
             Event::Start(tag) => {
                 item.spec.start = text.len() as u32;
-                stack.push(item.clone());
-                if item.tag(tag) {
-                    if first_para {
-                        first_para = false;
-                    } else {
-                        text.push_str("\n\n");
-                    }
+                if let Some(clone) = item.start_tag(&mut text, &mut line, tag) {
+                    stack.push(item);
+                    item = clone;
+                    item.spec.font_id = Some(fonts.load_font(item.sel.clone()).unwrap());
+                    formatting.set_last(item.spec);
                 }
-                item.spec.font_id = Some(fonts.load_font(item.sel.clone()).unwrap());
-                dbg!(&item.spec);
-                formatting.set_last(item.spec);
             }
-            Event::End(_) => {
-                if let Some(x) = stack.pop() {
-                    item = x;
+            Event::End(tag) => {
+                if item.end_tag(&mut line, tag) {
+                    item = stack.pop().unwrap();
                     item.spec.start = text.len() as u32;
-                    dbg!(&item.spec);
                     formatting.set_last(item.spec);
                 }
             }
             Event::Text(part) => text.push_str(&part),
-            Event::Code(part) => unimplemented!("{:?}", part),
+            Event::Code(part) => {
+                item.spec.start = text.len() as u32;
+                let mut item2 = item.clone();
+                item2.sel.set_families(vec![FamilyName::Monospace]);
+                item2.spec.font_id = Some(fonts.load_font(item2.sel).unwrap());
+                formatting.set_last(item2.spec);
+
+                text.push_str(&part);
+
+                item.spec.start = text.len() as u32;
+                formatting.set_last(item.spec);
+            }
             Event::Html(part) => unimplemented!("{:?}", part),
             Event::FootnoteReference(part) => unimplemented!("{:?}", part),
             Event::SoftBreak => (),
@@ -65,21 +69,132 @@ pub(crate) fn parse(input: &str) -> Text {
     Text { text, formatting }
 }
 
-#[derive(Clone, Debug, Default)]
+// Line state
+enum Line {
+    None,
+    Para,
+    Item,
+}
+
+impl Line {
+    fn paragraph(&mut self) -> &str {
+        let ret = match self {
+            Line::None => "",
+            _ => "\n\n",
+        };
+        *self = Line::Para;
+        ret
+    }
+    fn heading(&mut self) -> &str {
+        self.paragraph()
+    }
+    fn item(&mut self) -> &str {
+        let ret = match self {
+            Line::None => "",
+            Line::Para => "\n\n",
+            _ => "\n",
+        };
+        *self = Line::Item;
+        ret
+    }
+}
+
+// TODO: this is temporary
+const BASE_SIZE: f32 = 11.0;
+
+#[derive(Clone, Debug)]
 struct StackItem {
     sel: FontSelector,
+    list: Option<u64>,
     spec: FormatSpecifier,
 }
 
+impl Default for StackItem {
+    fn default() -> Self {
+        StackItem {
+            sel: Default::default(),
+            list: None,
+            spec: FormatSpecifier {
+                pt_size: BASE_SIZE,
+                ..Default::default()
+            },
+        }
+    }
+}
+
 impl StackItem {
-    // process a tag; return true on paragraph
-    fn tag(&mut self, tag: Tag) -> bool {
+    // process a tag; may modify current item and may return new item
+    fn start_tag(&mut self, text: &mut String, line: &mut Line, tag: Tag) -> Option<Self> {
+        fn with_clone<F: Fn(&mut StackItem)>(s: &mut StackItem, c: F) -> Option<StackItem> {
+            let mut item = s.clone();
+            c(&mut item);
+            Some(item)
+        }
+
         match tag {
-            Tag::Paragraph => return true,
-            Tag::Emphasis => self.sel.set_style(Style::Italic),
-            Tag::Strong => self.sel.set_weight(Weight::BOLD),
+            Tag::Paragraph => {
+                text.push_str(line.paragraph());
+                None
+            }
+            Tag::Heading(level) => {
+                text.push_str(line.heading());
+                self.spec.start = text.len() as u32;
+                with_clone(self, |item| {
+                    item.spec.pt_size = match level {
+                        1 => 2.0 * BASE_SIZE,
+                        2 => 1.75 * BASE_SIZE,
+                        3 => 1.5 * BASE_SIZE,
+                        4 => 1.35 * BASE_SIZE,
+                        5 => 1.2 * BASE_SIZE,
+                        level => panic!("Heading({}) not supported", level),
+                    }
+                })
+            }
+            Tag::CodeBlock(_) => {
+                text.push_str(line.item());
+                self.spec.start = text.len() as u32;
+                with_clone(self, |item| {
+                    item.sel.set_families(vec![FamilyName::Monospace])
+                })
+                // TODO: within a code block, the last \n should be suppressed?
+            }
+            Tag::List(start) => {
+                // TODO: a list is not a "line item", but should have extra space?
+                text.push_str(line.item());
+                self.list = start;
+                None
+            }
+            Tag::Item => {
+                text.push_str(line.item());
+                match &mut self.list {
+                    // TODO: indent properly
+                    Some(x) => {
+                        text.push_str(&format!("{:<4}", x));
+                        *x = *x + 1;
+                    }
+                    None => text.push_str("•   "),
+                }
+                None
+            }
+            Tag::Emphasis => with_clone(self, |item| item.sel.set_style(Style::Italic)),
+            Tag::Strong => with_clone(self, |item| item.sel.set_weight(Weight::BOLD)),
             tag @ _ => unimplemented!("{:?}", tag),
         }
-        false
+    }
+    // returns true if stack must be popped
+    fn end_tag(&self, line: &mut Line, tag: Tag) -> bool {
+        match tag {
+            Tag::Paragraph => {
+                *line = Line::Para;
+                false
+            }
+            Tag::Heading(_) => true,
+            Tag::CodeBlock(_) => true,
+            Tag::List(_) => false,
+            Tag::Item => false,
+            Tag::Emphasis => true,
+            Tag::Strong => true,
+            tag @ _ => unimplemented!("{:?}", tag),
+        }
     }
 }


### PR DESCRIPTION
Applies very basic highlighting to a subset of Markdown.
![markdown_parser](https://user-images.githubusercontent.com/134893/94251536-90b16980-ff1a-11ea-852f-fbd16cfaa7fe.png)

Extra line-break after the code block is caused by the parser: https://github.com/raphlinus/pulldown-cmark/issues/485