### PR TITLE
Remove ab_glyph, (late) underline and colour effects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ shaping = ["harfbuzz_rs"]
 markdown = ["pulldown-cmark"]
 
 [dependencies]
+bitflags = "1.2.1"
 ttf-parser = "0.8.2"
 font-kit = "0.8.0"
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ shaping = ["harfbuzz_rs"]
 markdown = ["pulldown-cmark"]
 
 [dependencies]
-ab_glyph = "0.2.5"
+ttf-parser = "0.8.2"
 font-kit = "0.8.0"
 lazy_static = "1.4.0"
 smallvec = "1.4.1"

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1,0 +1,69 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Type conversion utilities
+//!
+//! Many indices are represented as `u32` instead of `usize` by this library in
+//! order to save space (note that we do not expect `usize` smaller than `u32`
+//! and our text representations are not intended to scale anywhere close to
+//! `u32::MAX` bytes of text, so `u32` is always an appropriate index type).
+
+use std::mem::size_of;
+
+/// Convert `usize` → `u32`
+///
+/// This is a "safer" wrapper around `as` ensuring (on debug builds) that the
+/// input value may be represented correctly by `u32`.
+#[inline]
+pub fn to_u32(x: usize) -> u32 {
+    debug_assert!(x <= to_usize(u32::MAX));
+    x as u32
+}
+
+// Borrowed from static_assertions:
+macro_rules! const_assert {
+    ($x:expr $(,)?) => {
+        #[allow(unknown_lints, eq_op)]
+        const _: [(); 0 - !{
+            const ASSERT: bool = $x;
+            ASSERT
+        } as usize] = [];
+    };
+}
+
+/// Convert `u32` → `usize`
+///
+/// This is a "safer" wrapper around `as` ensuring that the operation is
+/// zero-extension.
+#[inline]
+pub fn to_usize(x: u32) -> usize {
+    const_assert!(size_of::<usize>() >= size_of::<u32>());
+    x as usize
+}
+
+/// Scale factor: pixels per font unit
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct DPU(pub(crate) f32);
+
+impl DPU {
+    pub(crate) fn i16_to_px(self, x: i16) -> f32 {
+        f32::from(x) * self.0
+    }
+    pub(crate) fn u16_to_px(self, x: u16) -> f32 {
+        f32::from(x) * self.0
+    }
+    pub(crate) fn to_line_metrics(self, metrics: ttf_parser::LineMetrics) -> LineMetrics {
+        LineMetrics {
+            position: self.i16_to_px(metrics.position),
+            thickness: self.i16_to_px(metrics.thickness),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct LineMetrics {
+    pub position: f32,
+    pub thickness: f32,
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -16,6 +16,18 @@ impl DPU {
     pub(crate) fn u16_to_px(self, x: u16) -> f32 {
         f32::from(x) * self.0
     }
+    pub(crate) fn to_line_metrics(self, metrics: ttf_parser::LineMetrics) -> LineMetrics {
+        LineMetrics {
+            position: self.i16_to_px(metrics.position),
+            thickness: self.i16_to_px(metrics.thickness),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct LineMetrics {
+    pub position: f32,
+    pub thickness: f32,
 }
 
 /// 2D size over `f32`

--- a/src/data.rs
+++ b/src/data.rs
@@ -86,6 +86,11 @@ impl Range {
         to_usize(self.end)
     }
 
+    /// The number of iterable items, as `usize`
+    pub fn len(self) -> usize {
+        to_usize(self.end) - to_usize(self.start)
+    }
+
     /// True if the given value is contained, inclusive of end points
     pub fn includes(self, value: usize) -> bool {
         to_usize(self.start) <= value && value <= to_usize(self.end)
@@ -95,40 +100,12 @@ impl Range {
     pub fn to_std(self) -> std::ops::Range<usize> {
         to_usize(self.start)..to_usize(self.end)
     }
-}
 
-impl std::iter::Iterator for Range {
-    type Item = u32;
-
-    fn next(&mut self) -> Option<u32> {
-        if self.start < self.end {
-            let result = self.start;
-            self.start += 1;
-            Some(result)
-        } else {
-            None
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = to_usize(self.end - self.start);
-        (len, Some(len))
+    /// Convert to `usize` and iterate
+    pub fn iter(self) -> impl Iterator<Item = usize> {
+        self.to_std()
     }
 }
-
-impl std::iter::DoubleEndedIterator for Range {
-    fn next_back(&mut self) -> Option<u32> {
-        if self.start < self.end {
-            self.end -= 1;
-            Some(self.end)
-        } else {
-            None
-        }
-    }
-}
-
-impl std::iter::ExactSizeIterator for Range {}
-impl std::iter::FusedIterator for Range {}
 
 impl std::ops::Index<Range> for String {
     type Output = str;

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,6 +5,19 @@
 
 //! KAS Rich-Text library — simple data types
 
+/// Scale factor: pixels per font unit
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) struct DPU(pub(crate) f32);
+
+impl DPU {
+    pub(crate) fn i16_to_px(self, x: i16) -> f32 {
+        f32::from(x) * self.0
+    }
+    pub(crate) fn u16_to_px(self, x: u16) -> f32 {
+        f32::from(x) * self.0
+    }
+}
+
 /// 2D size over `f32`
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Vec2(pub f32, pub f32);
@@ -56,21 +69,6 @@ impl std::ops::Sub for Vec2 {
 impl From<Vec2> for (f32, f32) {
     fn from(size: Vec2) -> Self {
         (size.0, size.1)
-    }
-}
-
-impl From<Vec2> for ab_glyph::Point {
-    fn from(size: Vec2) -> ab_glyph::Point {
-        ab_glyph::Point {
-            x: size.0,
-            y: size.1,
-        }
-    }
-}
-
-impl From<ab_glyph::Point> for Vec2 {
-    fn from(p: ab_glyph::Point) -> Vec2 {
-        Vec2(p.x, p.y)
     }
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,30 +5,7 @@
 
 //! KAS Rich-Text library — simple data types
 
-/// Scale factor: pixels per font unit
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub(crate) struct DPU(pub(crate) f32);
-
-impl DPU {
-    pub(crate) fn i16_to_px(self, x: i16) -> f32 {
-        f32::from(x) * self.0
-    }
-    pub(crate) fn u16_to_px(self, x: u16) -> f32 {
-        f32::from(x) * self.0
-    }
-    pub(crate) fn to_line_metrics(self, metrics: ttf_parser::LineMetrics) -> LineMetrics {
-        LineMetrics {
-            position: self.i16_to_px(metrics.position),
-            thickness: self.i16_to_px(metrics.thickness),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub(crate) struct LineMetrics {
-    pub position: f32,
-    pub thickness: f32,
-}
+use crate::conv::{to_u32, to_usize};
 
 /// 2D size over `f32`
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -101,22 +78,22 @@ pub struct Range {
 impl Range {
     /// The start, as `usize`
     pub fn start(self) -> usize {
-        self.start as usize
+        to_usize(self.start)
     }
 
     /// The end, as `usize`
     pub fn end(self) -> usize {
-        self.end as usize
+        to_usize(self.end)
     }
 
     /// True if the given value is contained, inclusive of end points
     pub fn includes(self, value: usize) -> bool {
-        self.start as usize <= value && value <= self.end as usize
+        to_usize(self.start) <= value && value <= to_usize(self.end)
     }
 
     /// Convert to a standard range
     pub fn to_std(self) -> std::ops::Range<usize> {
-        (self.start as usize)..(self.end as usize)
+        to_usize(self.start)..to_usize(self.end)
     }
 }
 
@@ -134,7 +111,7 @@ impl std::iter::Iterator for Range {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = (self.end - self.start) as usize;
+        let len = to_usize(self.end - self.start);
         (len, Some(len))
     }
 }
@@ -203,7 +180,7 @@ impl<T> std::ops::IndexMut<Range> for [T] {
 
 impl From<Range> for std::ops::Range<usize> {
     fn from(range: Range) -> std::ops::Range<usize> {
-        (range.start as usize)..(range.end as usize)
+        to_usize(range.start)..to_usize(range.end)
     }
 }
 
@@ -218,10 +195,10 @@ impl From<std::ops::Range<u32>> for Range {
 
 impl From<std::ops::Range<usize>> for Range {
     fn from(range: std::ops::Range<usize>) -> Range {
-        assert!(range.end <= u32::MAX as usize);
+        assert!(range.end <= to_usize(u32::MAX));
         Range {
-            start: range.start as u32,
-            end: range.end as u32,
+            start: to_u32(range.start),
+            end: to_u32(range.end),
         }
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -93,14 +93,14 @@ impl Environment {
         Self::default()
     }
 
-    /// Returns the height of a standard line
+    /// Returns the height of standard horizontal text
     ///
     /// This depends on the `pt_size` and `dpp` fields.
     ///
     /// To use "the standard font", use `Default::default()`.
-    pub fn line_height(&self, font_id: FontId) -> f32 {
+    pub fn height(&self, font_id: FontId) -> f32 {
         let dpem = self.pt_size * self.dpp;
-        fonts().get(font_id).line_height(dpem)
+        fonts().get(font_id).height(dpem)
     }
 }
 

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -20,7 +20,8 @@
 //! // from now on, kas_text::fonts::FontId::default() identifies the default font
 //! ```
 
-use crate::{GlyphId, LineMetrics, DPU};
+use crate::conv::{to_u32, to_usize, LineMetrics, DPU};
+use crate::GlyphId;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{RwLock, RwLockReadGuard};
@@ -57,7 +58,7 @@ enum FontError {
 pub struct FontId(pub u32);
 impl FontId {
     pub fn get(self) -> usize {
-        self.0 as usize
+        to_usize(self.0)
     }
 }
 
@@ -213,7 +214,7 @@ struct FontsData {
 
 impl FontsData {
     fn push(&mut self, font: Box<FaceStore<'static>>, sel_hash: u64, path_hash: u64) -> FontId {
-        let id = FontId(self.fonts.len() as u32);
+        let id = FontId(to_u32(self.fonts.len()));
         self.fonts.push(font);
         self.sel_hash.push((sel_hash, id));
         self.path_hash.push((path_hash, id));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod prepared;
 pub use prepared::*;
 
 pub(crate) mod shaper;
-pub use shaper::Glyph;
+pub use shaper::{Glyph, GlyphId};
 
 /// A string with formatting information
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,10 @@
 mod env;
 pub use env::*;
 
+pub mod conv;
+
 mod data;
-pub use data::*;
+pub use data::{Range, Vec2};
 
 pub mod fonts;
 pub mod parser;

--- a/src/prepared.rs
+++ b/src/prepared.rs
@@ -8,6 +8,7 @@
 use smallvec::SmallVec;
 use std::ops::{BitOr, BitOrAssign, Bound};
 
+use crate::conv::{to_u32, to_usize};
 use crate::parser::FormatData;
 use crate::{shaper, Vec2};
 use crate::{Environment, FormattedString, UpdateEnv};
@@ -246,7 +247,7 @@ impl Text {
     /// [`Text::set_text`]. This may change in the future (TODO).
     pub fn insert_char(&mut self, index: usize, c: char) -> PrepareAction {
         self.text.insert(index, c);
-        self.fmt.insert_range(index as u32, c.len_utf8() as u32);
+        self.fmt.insert_range(to_u32(index), to_u32(c.len_utf8()));
         self.action = Action::Runs;
         true.into()
     }
@@ -278,9 +279,9 @@ impl Text {
             Bound::Unbounded => usize::MAX,
         };
         self.text.replace_range(start..end, replace_with);
-        self.fmt.remove_range(start as u32, end as u32);
+        self.fmt.remove_range(to_u32(start), to_u32(end));
         self.fmt
-            .insert_range(start as u32, replace_with.len() as u32);
+            .insert_range(to_u32(start), to_u32(replace_with.len()));
         self.action = Action::Runs;
         true.into()
     }
@@ -432,7 +433,7 @@ impl Text {
     pub fn line_is_ltr(&self, line: usize) -> bool {
         assert!(self.action.is_none(), "kas-text::Text: not ready");
         let first_run = self.lines[line].run_range.start();
-        let glyph_run = self.wrapped_runs[first_run].glyph_run as usize;
+        let glyph_run = to_usize(self.wrapped_runs[first_run].glyph_run);
         self.glyph_runs[glyph_run].level.is_ltr()
     }
 
@@ -489,7 +490,7 @@ impl Text {
         };
 
         for run_part in &self.wrapped_runs[run_range] {
-            let glyph_run = &self.glyph_runs[run_part.glyph_run as usize];
+            let glyph_run = &self.glyph_runs[to_usize(run_part.glyph_run)];
             let rel_pos = x - run_part.offset.0;
 
             let end_index;
@@ -517,6 +518,6 @@ impl Text {
             try_best((end_pos - rel_pos).abs(), end_index);
         }
 
-        Some(best as usize)
+        Some(to_usize(best))
     }
 }

--- a/src/prepared.rs
+++ b/src/prepared.rs
@@ -15,7 +15,7 @@ use crate::{Environment, FormattedString, UpdateEnv};
 mod glyph_pos;
 mod text_runs;
 mod wrap_lines;
-pub use glyph_pos::{MarkerPos, MarkerPosIter};
+pub use glyph_pos::{Effect, EffectFlags, MarkerPos, MarkerPosIter};
 pub(crate) use text_runs::{LineRun, Run};
 use wrap_lines::{Line, RunPart};
 
@@ -385,13 +385,13 @@ impl Text {
     /// before this method. Note that initial size bounds may cause wrapping
     /// and may cause parts of the text outside the bounds to be cut off.
     pub fn required_size(&self) -> Vec2 {
-        assert!(self.action.is_none(), "kas-text::prepared::Text: not ready");
+        assert!(self.action.is_none(), "kas-text::Text: not ready");
         self.required
     }
 
     /// Get the number of lines
     pub fn num_lines(&self) -> usize {
-        assert!(self.action.is_none(), "kas-text::prepared::Text: not ready");
+        assert!(self.action.is_none(), "kas-text::Text: not ready");
         self.lines.len()
     }
 
@@ -403,7 +403,7 @@ impl Text {
     /// (which means either that `index` is beyond the end of the text or that
     /// `index` is within a mult-byte line break).
     pub fn find_line(&self, index: usize) -> Option<(usize, std::ops::Range<usize>)> {
-        assert!(self.action.is_none(), "kas-text::prepared::Text: not ready");
+        assert!(self.action.is_none(), "kas-text::Text: not ready");
         let mut first = None;
         for (n, line) in self.lines.iter().enumerate() {
             if line.text_range.end() == index {
@@ -420,7 +420,7 @@ impl Text {
 
     /// Get the range of a line, by line number
     pub fn line_range(&self, line: usize) -> Option<std::ops::Range<usize>> {
-        assert!(self.action.is_none(), "kas-text::prepared::Text: not ready");
+        assert!(self.action.is_none(), "kas-text::Text: not ready");
         self.lines.get(line).map(|line| line.text_range.to_std())
     }
 
@@ -430,7 +430,7 @@ impl Text {
     ///
     /// Panics if `line >= self.num_lines()`.
     pub fn line_is_ltr(&self, line: usize) -> bool {
-        assert!(self.action.is_none(), "kas-text::prepared::Text: not ready");
+        assert!(self.action.is_none(), "kas-text::Text: not ready");
         let first_run = self.lines[line].run_range.start();
         let glyph_run = self.wrapped_runs[first_run].glyph_run as usize;
         self.glyph_runs[glyph_run].level.is_ltr()
@@ -443,7 +443,7 @@ impl Text {
     /// Panics if `line >= self.num_lines()`.
     #[inline]
     pub fn line_is_rtl(&self, line: usize) -> bool {
-        assert!(self.action.is_none(), "kas-text::prepared::Text: not ready");
+        assert!(self.action.is_none(), "kas-text::Text: not ready");
         !self.line_is_ltr(line)
     }
 
@@ -455,7 +455,7 @@ impl Text {
     /// Note: if the font's rect does not start at the origin, then its top-left
     /// coordinate should first be subtracted from `pos`.
     pub fn text_index_nearest(&self, pos: Vec2) -> usize {
-        assert!(self.action.is_none(), "kas-text::prepared::Text: not ready");
+        assert!(self.action.is_none(), "kas-text::Text: not ready");
         let mut n = 0;
         for (i, line) in self.lines.iter().enumerate() {
             if line.top > pos.1 {
@@ -472,7 +472,7 @@ impl Text {
     /// This is similar to [`Text::text_index_nearest`], but allows the line to
     /// be specified explicitly. Returns `None` only on invalid `line`.
     pub fn line_index_nearest(&self, line: usize, x: f32) -> Option<usize> {
-        assert!(self.action.is_none(), "kas-text::prepared::Text: not ready");
+        assert!(self.action.is_none(), "kas-text::Text: not ready");
         if line >= self.lines.len() {
             return None;
         }

--- a/src/prepared/glyph_pos.rs
+++ b/src/prepared/glyph_pos.rs
@@ -7,7 +7,6 @@
 
 use super::Text;
 use crate::{fonts::fonts, Vec2};
-use ab_glyph::ScaleFont;
 
 /// Used to return the position of a glyph with associated metrics
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -137,7 +136,7 @@ impl Text {
             }
 
             let glyph_run = &self.glyph_runs[run_part.glyph_run as usize];
-            let sf = fonts().get(glyph_run.font_id).scaled(glyph_run.font_scale);
+            let sf = fonts().get(glyph_run.font_id).scale_by_dpu(glyph_run.dpu);
 
             // If index is at the end of a run, we potentially get two matches.
             if index == run_part.text_end as usize {
@@ -337,7 +336,7 @@ impl Text {
             }
 
             let glyph_run = &self.glyph_runs[run_part.glyph_run as usize];
-            let sf = fonts().get(glyph_run.font_id).scaled(glyph_run.font_scale);
+            let sf = fonts().get(glyph_run.font_id).scale_by_dpu(glyph_run.dpu);
 
             // else: range.start < run_part.text_end as usize
             if glyph_run.level.is_ltr() {
@@ -365,7 +364,7 @@ impl Text {
         'a: while i < run_range.end {
             let run_part = &self.wrapped_runs[i];
             let glyph_run = &self.glyph_runs[run_part.glyph_run as usize];
-            let sf = fonts().get(glyph_run.font_id).scaled(glyph_run.font_scale);
+            let sf = fonts().get(glyph_run.font_id).scale_by_dpu(glyph_run.dpu);
 
             if !first {
                 a = if glyph_run.level.is_ltr() {

--- a/src/prepared/glyph_pos.rs
+++ b/src/prepared/glyph_pos.rs
@@ -6,6 +6,7 @@
 //! Text navigation
 
 use super::Text;
+use crate::conv::to_usize;
 use crate::fonts::{fonts, FontId, ScaledFaceRef};
 use crate::{Glyph, Vec2};
 
@@ -146,7 +147,7 @@ impl Text {
         let mut v: [MarkerPos; 2] = Default::default();
         let (a, mut b) = (0, 0);
         let mut push_result = |pos, ascent, descent, level| {
-            v[b as usize] = MarkerPos {
+            v[b] = MarkerPos {
                 pos,
                 ascent,
                 descent,
@@ -157,15 +158,15 @@ impl Text {
 
         // We don't care too much about performance: use a naive search strategy
         'a: for run_part in &self.wrapped_runs {
-            if index > run_part.text_end as usize {
+            if index > to_usize(run_part.text_end) {
                 continue;
             }
 
-            let glyph_run = &self.glyph_runs[run_part.glyph_run as usize];
+            let glyph_run = &self.glyph_runs[to_usize(run_part.glyph_run)];
             let sf = fonts().get(glyph_run.font_id).scale_by_dpu(glyph_run.dpu);
 
             // If index is at the end of a run, we potentially get two matches.
-            if index == run_part.text_end as usize {
+            if index == to_usize(run_part.text_end) {
                 let i = if glyph_run.level.is_ltr() {
                     run_part.glyph_range.end()
                 } else {
@@ -183,17 +184,17 @@ impl Text {
                 continue;
             }
 
-            // else: index < run_part.text_end as usize
+            // else: index < to_usize(run_part.text_end)
             let pos = 'b: loop {
                 if glyph_run.level.is_ltr() {
                     for glyph in glyph_run.glyphs[run_part.glyph_range.to_std()].iter().rev() {
-                        if glyph.index as usize <= index {
+                        if to_usize(glyph.index) <= index {
                             break 'b glyph.position;
                         }
                     }
                 } else {
                     for glyph in glyph_run.glyphs[run_part.glyph_range.to_std()].iter() {
-                        if glyph.index as usize <= index {
+                        if to_usize(glyph.index) <= index {
                             let mut pos = glyph.position;
                             pos.0 += sf.h_advance(glyph.id);
                             break 'b pos;
@@ -216,7 +217,7 @@ impl Text {
     /// This method is a simple memory-read.
     #[inline]
     pub fn num_glyphs(&self) -> usize {
-        self.num_glyphs as usize
+        to_usize(self.num_glyphs)
     }
 
     /// Yield a sequence of positioned glyphs
@@ -244,7 +245,7 @@ impl Text {
 
         // self.wrapped_runs is in logical order
         for run_part in self.wrapped_runs.iter().cloned() {
-            let run = &self.glyph_runs[run_part.glyph_run as usize];
+            let run = &self.glyph_runs[to_usize(run_part.glyph_run)];
             let font_id = run.font_id;
             let dpu = run.dpu.0;
             let height = run.height;
@@ -306,7 +307,7 @@ impl Text {
                 continue;
             }
 
-            let run = &self.glyph_runs[run_part.glyph_run as usize];
+            let run = &self.glyph_runs[to_usize(run_part.glyph_run)];
             let font_id = run.font_id;
             let dpu = run.dpu.0;
             let height = run.height;
@@ -480,7 +481,7 @@ impl Text {
                 // find the rect nearest the line's end and extend
                 let mut nearest = 0;
                 let first_run = cur_line.run_range.start();
-                let glyph_run = self.wrapped_runs[first_run].glyph_run as usize;
+                let glyph_run = to_usize(self.wrapped_runs[first_run].glyph_run);
                 if self.glyph_runs[glyph_run].level.is_ltr() {
                     let mut dist = rbound - (rects[0].1).0;
                     for i in 1..rects.len() {
@@ -579,18 +580,18 @@ impl Text {
                 return;
             }
             let run_part = &self.wrapped_runs[i];
-            if range.start >= run_part.text_end as usize {
+            if range.start >= to_usize(run_part.text_end) {
                 i += 1;
                 continue;
             }
 
-            let glyph_run = &self.glyph_runs[run_part.glyph_run as usize];
+            let glyph_run = &self.glyph_runs[to_usize(run_part.glyph_run)];
             let sf = fonts().get(glyph_run.font_id).scale_by_dpu(glyph_run.dpu);
 
-            // else: range.start < run_part.text_end as usize
+            // else: range.start < to_usize(run_part.text_end)
             if glyph_run.level.is_ltr() {
                 for glyph in glyph_run.glyphs[run_part.glyph_range.to_std()].iter().rev() {
-                    if glyph.index as usize <= range.start {
+                    if to_usize(glyph.index) <= range.start {
                         a = glyph.position;
                         break 'b;
                     }
@@ -598,7 +599,7 @@ impl Text {
                 a = Vec2::ZERO;
             } else {
                 for glyph in glyph_run.glyphs[run_part.glyph_range.to_std()].iter() {
-                    if glyph.index as usize <= range.start {
+                    if to_usize(glyph.index) <= range.start {
                         a = glyph.position;
                         a.0 += sf.h_advance(glyph.id);
                         break 'b;
@@ -613,7 +614,7 @@ impl Text {
         'a: while i < run_range.end {
             let run_part = &self.wrapped_runs[i];
             let offset = run_part.offset;
-            let glyph_run = &self.glyph_runs[run_part.glyph_run as usize];
+            let glyph_run = &self.glyph_runs[to_usize(run_part.glyph_run)];
             let sf = fonts().get(glyph_run.font_id).scale_by_dpu(glyph_run.dpu);
 
             if !first {
@@ -633,7 +634,7 @@ impl Text {
             }
             first = false;
 
-            if range.end >= run_part.text_end as usize {
+            if range.end >= to_usize(run_part.text_end) {
                 let b;
                 if glyph_run.level.is_ltr() {
                     if run_part.glyph_range.end() < glyph_run.glyphs.len() {
@@ -657,19 +658,19 @@ impl Text {
                 continue;
             }
 
-            // else: range.end < run_part.text_end as usize
+            // else: range.end < to_usize(run_part.text_end)
             let b;
             'c: loop {
                 if glyph_run.level.is_ltr() {
                     for glyph in glyph_run.glyphs[run_part.glyph_range.to_std()].iter().rev() {
-                        if glyph.index as usize <= range.end {
+                        if to_usize(glyph.index) <= range.end {
                             b = glyph.position;
                             break 'c;
                         }
                     }
                 } else {
                     for glyph in glyph_run.glyphs[run_part.glyph_range.to_std()].iter() {
-                        if glyph.index as usize <= range.end {
+                        if to_usize(glyph.index) <= range.end {
                             let mut p = glyph.position;
                             p.0 += sf.h_advance(glyph.id);
                             b = Vec2(a.0, p.1);

--- a/src/prepared/text_runs.rs
+++ b/src/prepared/text_runs.rs
@@ -6,6 +6,7 @@
 //! Text preparation: line breaking and BIDI
 
 use super::Text;
+use crate::conv::{to_u32, to_usize};
 use crate::fonts::FontId;
 use crate::{Direction, Range};
 use smallvec::SmallVec;
@@ -122,14 +123,14 @@ impl Text {
 
             let fmt_break = next_fmt
                 .as_ref()
-                .map(|fmt| fmt.start as usize == pos)
+                .map(|fmt| to_usize(fmt.start) == pos)
                 .unwrap_or(false);
 
             if hard_break || bidi_break || fmt_break {
                 let mut range = trim_control(&self.text.as_str()[start..pos]);
                 // trim_control gives us a range within the slice; we need to offset:
-                range.start += start as u32;
-                range.end += start as u32;
+                range.start += to_u32(start);
+                range.end += to_u32(start);
 
                 self.runs.push(Run {
                     range,
@@ -141,7 +142,7 @@ impl Text {
                 });
 
                 if let Some(fmt) = next_fmt.as_ref() {
-                    if fmt.start as usize == pos {
+                    if to_usize(fmt.start) == pos {
                         font_id = fmt.font_id;
                         dpem = fmt.dpem;
                         next_fmt = fmt_iter.next();
@@ -164,7 +165,7 @@ impl Text {
                     next_break = breaks_iter.next().unwrap_or((0, false));
                 }
             } else if is_break {
-                breaks.push(pos as u32);
+                breaks.push(to_u32(pos));
                 next_break = breaks_iter.next().unwrap_or((0, false));
             }
         }
@@ -174,8 +175,8 @@ impl Text {
         // regardless of whether the text ends with a line-break char.
         let mut range = trim_control(&self.text.as_str()[start..]);
         // trim_control gives us a range within the slice; we need to offset:
-        range.start += start as u32;
-        range.end += start as u32;
+        range.start += to_u32(start);
+        range.end += to_u32(start);
         self.runs.push(Run {
             range,
             dpem,

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -80,7 +80,7 @@ impl Text {
                     if line_len > width_bound && end.2 > 0 {
                         // Add up to last valid break point then wrap and reset
                         let slice = &mut parts[0..end.2];
-                        adder.add_line(fonts, level, end_len, &self.glyph_runs, slice);
+                        adder.add_line(fonts, level, end_len, &self.glyph_runs, slice, true);
 
                         end.2 = 0;
                         start = end;
@@ -137,7 +137,7 @@ impl Text {
             if parts.len() > 0 {
                 // It should not be possible for a line to end with a no-break, so:
                 debug_assert_eq!(parts.len(), end.2);
-                adder.add_line(fonts, level, end_len, &self.glyph_runs, &mut parts);
+                adder.add_line(fonts, level, end_len, &self.glyph_runs, &mut parts, false);
             }
         }
 
@@ -177,6 +177,7 @@ impl LineAdder {
         line_len: f32,
         runs: &[GlyphRun],
         parts: &mut [PartInfo],
+        is_wrap: bool,
     ) {
         assert!(parts.len() > 0);
         let line_start = self.runs.len();
@@ -231,7 +232,7 @@ impl LineAdder {
             let part = &mut parts[parts.len() - 1];
             let run = &runs[part.run as usize];
 
-            if part.len > part.len_no_space {
+            if is_wrap && part.len > part.len_no_space {
                 // When wrapping on whitespace: exclude the last glyph
                 // This excludes only one glyph; the main aim is to make the
                 // 'End' key exclude the wrapping position (which is also the

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -9,7 +9,6 @@ use super::Text;
 use crate::fonts::{fonts, FontLibrary};
 use crate::shaper::GlyphRun;
 use crate::{Align, Environment, Range, Vec2};
-use ab_glyph::ScaleFont;
 use smallvec::SmallVec;
 use unicode_bidi::Level;
 
@@ -194,7 +193,7 @@ impl LineAdder {
             last_run = part.run;
             let run = &runs[last_run as usize];
 
-            let scale_font = fonts.get(run.font_id).scaled(run.font_scale);
+            let scale_font = fonts.get(run.font_id).scale_by_dpu(run.dpu);
             ascent = ascent.max(scale_font.ascent());
             descent = descent.min(scale_font.descent());
             line_gap = line_gap.max(scale_font.line_gap());

--- a/src/prepared/wrap_lines.rs
+++ b/src/prepared/wrap_lines.rs
@@ -6,6 +6,7 @@
 //! Text prepared for display
 
 use super::Text;
+use crate::conv::{to_u32, to_usize};
 use crate::fonts::{fonts, FontLibrary};
 use crate::shaper::GlyphRun;
 use crate::{Align, Environment, Range, Vec2};
@@ -96,11 +97,11 @@ impl Text {
                         || (justify && part_len_no_space > 0.0)
                         || parts
                             .last()
-                            .map(|part| (part.run as usize) < index)
+                            .map(|part| to_usize(part.run) < index)
                             .unwrap_or(true)
                     {
                         parts.push(PartInfo {
-                            run: index as u32,
+                            run: to_u32(index),
                             offset: part_offset,
                             len: part_len,
                             len_no_space: part_len_no_space,
@@ -192,7 +193,7 @@ impl LineAdder {
                 continue;
             }
             last_run = part.run;
-            let run = &runs[last_run as usize];
+            let run = &runs[to_usize(last_run)];
 
             let scale_font = fonts.get(run.font_id).scale_by_dpu(run.dpu);
             ascent = ascent.max(scale_font.ascent());
@@ -208,7 +209,7 @@ impl LineAdder {
 
         let line_text_start = {
             let part = &parts[0];
-            let run = &runs[part.run as usize];
+            let run = &runs[to_usize(part.run)];
             if run.level.is_ltr() {
                 if part.glyph_range.start() < run.glyphs.len() {
                     run.glyphs[part.glyph_range.start()].index
@@ -230,7 +231,7 @@ impl LineAdder {
         let mut line_text_end;
         {
             let part = &mut parts[parts.len() - 1];
-            let run = &runs[part.run as usize];
+            let run = &runs[to_usize(part.run)];
 
             if is_wrap && part.len > part.len_no_space {
                 // When wrapping on whitespace: exclude the last glyph
@@ -260,7 +261,7 @@ impl LineAdder {
             }
 
             for part in parts.iter_mut().rev() {
-                let run = &runs[part.run as usize];
+                let run = &runs[to_usize(part.run)];
 
                 if run.level.is_rtl() {
                     part.offset += part.len - part.len_no_space;
@@ -285,7 +286,7 @@ impl LineAdder {
             while level > Level::ltr() {
                 let mut start = None;
                 for i in 0..parts.len() {
-                    let part_level = runs[parts[i].run as usize].level;
+                    let part_level = runs[to_usize(parts[i].run)].level;
                     if let Some(s) = start {
                         if part_level < level {
                             parts[s..i].reverse();
@@ -320,7 +321,7 @@ impl LineAdder {
                 is_gap.resize(len, false);
                 let mut num_gaps = 0;
                 for (i, part) in parts[..len - 1].iter().enumerate() {
-                    let run = &runs[part.run as usize];
+                    let run = &runs[to_usize(part.run)];
                     let not_at_end = if run.level.is_ltr() {
                         part.glyph_range.end() < run.glyphs.len()
                     } else {
@@ -334,9 +335,9 @@ impl LineAdder {
 
                 // Apply per-level reversing to is_gap
                 let mut start = 0;
-                let mut level = runs[parts[0].run as usize].level;
+                let mut level = runs[to_usize(parts[0].run)].level;
                 for i in 1..len {
-                    let new_level = runs[parts[i].run as usize].level;
+                    let new_level = runs[to_usize(parts[i].run)].level;
                     if level != new_level {
                         if level > line_level {
                             is_gap[start..i].reverse();
@@ -360,9 +361,9 @@ impl LineAdder {
         };
 
         for (i, part) in parts.iter().enumerate() {
-            let run = &runs[part.run as usize];
+            let run = &runs[to_usize(part.run)];
 
-            self.num_glyphs += part.glyph_range.len() as u32;
+            self.num_glyphs += to_u32(part.glyph_range.len());
 
             let mut text_end = run.range.end;
             if run.level.is_ltr() {

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -17,7 +17,7 @@
 //!
 //! This module *does not* perform line-breaking, wrapping or text reversal.
 
-use crate::fonts::{fonts, FontId, ScaledFaceRef};
+use crate::fonts::{fonts, FontId};
 use crate::{prepared, Range, Vec2, DPU};
 use smallvec::SmallVec;
 use unicode_bidi::Level;
@@ -349,7 +349,7 @@ fn shape_harfbuzz(
 // Simple implementation (kerning but no shaping)
 #[cfg(not(feature = "harfbuzz_rs"))]
 fn shape_simple(
-    sf: ScaledFaceRef,
+    sf: crate::fonts::ScaledFaceRef,
     text: &str,
     run: &prepared::Run,
 ) -> (Vec<Glyph>, SmallVec<[GlyphBreak; 2]>, f32, f32) {


### PR DESCRIPTION
First, this removes the `ab_glyph` dependency and uses `ttf-parser` directly. Rationale is partly that @alexheretic does not wish to pin `ab_glyph` to `ttf-parser` or re-export all the font information we need, and partly to allow `kas-text` to be used with other renderers. Instead we provide access to the byte-arrays of loaded fonts and allow these to be loaded again (even a third time when HarfBuzz also loads them for shaping).

Second, this adds `Text::glyphs_with_effects` with a new `Effect` struct to support colour selection, underline and strikethough. This API is temporary but the implementation should be final.

Finally, there are a few small improvements.