### PR TITLE
Revisions (Text/TextDisplay modularity)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ shaping = ["harfbuzz_rs"]
 # Enable Markdown parsing
 markdown = ["pulldown-cmark"]
 
+# Use Generic Associated Types (experimental)
+gat = []
+
 [dependencies]
 bitflags = "1.2.1"
 ttf-parser = "0.8.2"

--- a/src/display.rs
+++ b/src/display.rs
@@ -221,7 +221,7 @@ impl TextDisplay {
     /// method only performs the required steps. Updating line-wrapping due to
     /// changes in available width is significantly faster than updating the
     /// source text.
-    pub fn prepare(&mut self, text: &dyn FormattableText) {
+    pub fn prepare<F: FormattableText>(&mut self, text: &F) {
         let action = self.action;
         if action == Action::None {
             return;

--- a/src/display.rs
+++ b/src/display.rs
@@ -128,7 +128,7 @@ impl TextDisplay {
             self.resize_runs(text, env.dpp, env.pt_size);
         }
 
-        self.prepare_lines(env.bounds, env.wrap, (env.halign, env.valign));
+        self.prepare_lines(env.bounds, env.wrap, env.align);
     }
 
     /// Get the number of lines

--- a/src/display.rs
+++ b/src/display.rs
@@ -21,7 +21,7 @@ use wrap_lines::{Line, RunPart};
 /// Text display, without source text representation
 ///
 /// In general, it is recommended to use [`crate::Text`] instead, which includes
-/// a representation of the source text.
+/// a representation of the source text and environment state.
 ///
 /// Once prepared (via [`TextDisplay::prepare`]), this struct contains
 /// everything needed to display text, query glyph position and size
@@ -78,8 +78,8 @@ pub struct TextDisplay {
     width: f32,
 }
 
-impl TextDisplay {
-    pub(crate) fn new() -> Self {
+impl Default for TextDisplay {
+    fn default() -> Self {
         TextDisplay {
             runs: Default::default(),
             line_runs: Default::default(),
@@ -91,7 +91,9 @@ impl TextDisplay {
             width: 0.0,
         }
     }
+}
 
+impl TextDisplay {
     /// Require an action
     ///
     /// Required actions are tracked internally. This combines internal action

--- a/src/display.rs
+++ b/src/display.rs
@@ -9,7 +9,7 @@ use smallvec::SmallVec;
 
 use crate::conv::to_usize;
 use crate::format::FormattableText;
-use crate::{shaper, Action, Environment, Vec2};
+use crate::{shaper, Action, EnvFlags, Environment, Vec2};
 
 mod glyph_pos;
 mod text_runs;
@@ -122,13 +122,15 @@ impl TextDisplay {
         self.action = Action::None;
 
         if action >= Action::All {
-            self.prepare_runs(text, env.bidi, env.dir, env.dpp, env.pt_size);
+            let bidi = env.flags.contains(EnvFlags::BIDI);
+            self.prepare_runs(text, bidi, env.dir, env.dpp, env.pt_size);
         } else if action == Action::Resize {
             // Note: this is only needed if we didn't just call prepare_runs()
             self.resize_runs(text, env.dpp, env.pt_size);
         }
 
-        self.prepare_lines(env.bounds, env.wrap, env.align);
+        let wrap = env.flags.contains(EnvFlags::WRAP);
+        self.prepare_lines(env.bounds, wrap, env.align);
     }
 
     /// Get the number of lines

--- a/src/display.rs
+++ b/src/display.rs
@@ -94,6 +94,12 @@ impl Default for TextDisplay {
 }
 
 impl TextDisplay {
+    /// Get required action
+    #[inline]
+    pub fn required_action(&self) -> Action {
+        self.action
+    }
+
     /// Require an action
     ///
     /// Required actions are tracked internally. This combines internal action

--- a/src/display.rs
+++ b/src/display.rs
@@ -6,11 +6,10 @@
 //! Text prepared for display
 
 use smallvec::SmallVec;
-use std::ops::{BitOr, BitOrAssign};
 
 use crate::conv::to_usize;
 use crate::format::FormattableText;
-use crate::{shaper, Environment, Vec2};
+use crate::{shaper, Action, Environment, Vec2};
 
 mod glyph_pos;
 mod text_runs;
@@ -18,91 +17,6 @@ mod wrap_lines;
 pub use glyph_pos::{Effect, EffectFlags, MarkerPos, MarkerPosIter};
 pub(crate) use text_runs::{LineRun, Run};
 use wrap_lines::{Line, RunPart};
-
-/// Type used to indicate whether the [`TextDisplay`] object is ready for use
-///
-/// The user doesn't need to *do* anything with this value when returned from
-/// [`TextDisplay`] methods, but if [`PrepareAction::prepare`] returns true then
-/// the user must call [`TextDisplay::prepare`] before calling most other methods.
-///
-/// Multiple instances may be combined via the `|` (bit or) and `|=` operators.
-#[must_use]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub struct PrepareAction(bool);
-
-impl PrepareAction {
-    /// Construct an instance not requiring prepare
-    ///
-    /// This may be useful when optionally calling multiple update methods:
-    /// ```
-    /// use kas_text::{PrepareAction, Text, Environment};
-    ///
-    /// fn update_text(text: &mut Text<String>, opt_new_text: Option<String>, env: &Environment) {
-    ///     let mut prepare = PrepareAction::none();
-    ///     if let Some(new_text) = opt_new_text {
-    ///         prepare |= text.set_text(new_text.into());
-    ///     }
-    ///     if prepare.prepare() {
-    ///         text.prepare(env);
-    ///     }
-    /// }
-    /// ```
-    #[inline]
-    pub fn none() -> Self {
-        PrepareAction(false)
-    }
-
-    /// When true, [`TextDisplay::prepare`] must be called
-    #[inline]
-    pub fn prepare(self) -> bool {
-        self.0
-    }
-}
-
-impl BitOr for PrepareAction {
-    type Output = Self;
-
-    #[inline]
-    fn bitor(self, rhs: Self) -> Self {
-        PrepareAction(self.0 || rhs.0)
-    }
-}
-
-impl BitOrAssign for PrepareAction {
-    #[inline]
-    fn bitor_assign(&mut self, rhs: Self) {
-        self.0 = self.0 || rhs.0;
-    }
-}
-
-impl From<bool> for PrepareAction {
-    #[inline]
-    fn from(prepare: bool) -> Self {
-        PrepareAction(prepare)
-    }
-}
-
-impl From<Action> for PrepareAction {
-    #[inline]
-    fn from(action: Action) -> Self {
-        PrepareAction(action != Action::None)
-    }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub(crate) enum Action {
-    None,  // do nothing
-    Wrap,  // do line-wrapping and alignment
-    Shape, // do text shaping and above
-    Dpem,  // update font size, redo shaping and above
-    Runs,  // do splitting into runs, BIDI and above
-}
-
-impl Action {
-    fn is_none(&self) -> bool {
-        *self == Action::None
-    }
-}
 
 /// Text display, without source text representation
 ///
@@ -162,6 +76,7 @@ pub struct TextDisplay {
     /// Visual (wrapped) lines, in visual and logical order
     lines: Vec<Line>,
     num_glyphs: u32,
+    /// Required for highlight_lines; may remove later:
     width: f32,
 }
 
@@ -170,7 +85,7 @@ impl TextDisplay {
         TextDisplay {
             runs: Default::default(),
             line_runs: Default::default(),
-            action: Action::Runs, // highest value
+            action: Action::All, // highest value
             required: Default::default(),
             glyph_runs: Default::default(),
             wrapped_runs: Default::default(),
@@ -180,55 +95,46 @@ impl TextDisplay {
         }
     }
 
-    /// Prepare text for display
+    /// Require an action
     ///
-    /// The required preparation/update steps are tracked internally; this
-    /// method only performs the required steps. Updating line-wrapping due to
-    /// changes in available width is significantly faster than updating the
-    /// source text.
+    /// Required actions are tracked internally. This combines internal action
+    /// state with that input via `max`. It may be used, for example, to mark
+    /// that fonts need resizing due to change in environment.
+    #[inline]
+    pub fn require_action(&mut self, action: Action) {
+        self.action = self.action.max(action);
+    }
+
+    /// Prepare text for display, as necessary
+    ///
+    /// Does all preparation steps necessary in order to display or query the
+    /// layout of this text.
+    ///
+    /// Required preparation actions are tracked internally, but cannot
+    /// notice changes in the environment. In case the environment has changed
+    /// one should either call [`TextDisplay::require_action`] before this
+    /// method or use the [`TextDisplay::prepare_runs`],
+    /// [`TextDisplay::resize_runs`] and [`TextDisplay::prepare_lines`] methods.
     pub fn prepare<F: FormattableText>(&mut self, text: &F, env: &Environment) {
         let action = self.action;
         if action == Action::None {
             return;
         }
-
-        if action >= Action::Runs {
-            self.prepare_runs(text, env);
-        }
-
-        if action == Action::Dpem {
-            // Note: this is only needed if we didn't just call prepare_runs()
-            self.update_run_dpem(text, env);
-        }
-
-        if action >= Action::Shape {
-            self.glyph_runs = self
-                .runs
-                .iter()
-                .map(|run| shaper::shape(text.as_str(), &run))
-                .collect();
-        }
-
-        if action >= Action::Wrap {
-            self.wrap_lines(env);
-        }
-
         self.action = Action::None;
-    }
 
-    /// Get size requirements
-    ///
-    /// One must set initial size bounds and call [`TextDisplay::prepare`]
-    /// before this method. Note that initial size bounds may cause wrapping
-    /// and may cause parts of the text outside the bounds to be cut off.
-    pub fn required_size(&self) -> Vec2 {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
-        self.required
+        if action >= Action::All {
+            self.prepare_runs(text, env.bidi, env.dir, env.dpp, env.pt_size);
+        } else if action == Action::Resize {
+            // Note: this is only needed if we didn't just call prepare_runs()
+            self.resize_runs(text, env.dpp, env.pt_size);
+        }
+
+        self.prepare_lines(env.bounds, env.wrap, (env.halign, env.valign));
     }
 
     /// Get the number of lines
     pub fn num_lines(&self) -> usize {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
         self.lines.len()
     }
 
@@ -240,7 +146,7 @@ impl TextDisplay {
     /// (which means either that `index` is beyond the end of the text or that
     /// `index` is within a mult-byte line break).
     pub fn find_line(&self, index: usize) -> Option<(usize, std::ops::Range<usize>)> {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
         let mut first = None;
         for (n, line) in self.lines.iter().enumerate() {
             if line.text_range.end() == index {
@@ -257,7 +163,7 @@ impl TextDisplay {
 
     /// Get the range of a line, by line number
     pub fn line_range(&self, line: usize) -> Option<std::ops::Range<usize>> {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
         self.lines.get(line).map(|line| line.text_range.to_std())
     }
 
@@ -267,7 +173,7 @@ impl TextDisplay {
     ///
     /// Panics if `line >= self.num_lines()`.
     pub fn line_is_ltr(&self, line: usize) -> bool {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
         let first_run = self.lines[line].run_range.start();
         let glyph_run = to_usize(self.wrapped_runs[first_run].glyph_run);
         self.glyph_runs[glyph_run].level.is_ltr()
@@ -280,7 +186,7 @@ impl TextDisplay {
     /// Panics if `line >= self.num_lines()`.
     #[inline]
     pub fn line_is_rtl(&self, line: usize) -> bool {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
         !self.line_is_ltr(line)
     }
 
@@ -292,7 +198,7 @@ impl TextDisplay {
     /// Note: if the font's rect does not start at the origin, then its top-left
     /// coordinate should first be subtracted from `pos`.
     pub fn text_index_nearest(&self, pos: Vec2) -> usize {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
         let mut n = 0;
         for (i, line) in self.lines.iter().enumerate() {
             if line.top > pos.1 {
@@ -309,7 +215,7 @@ impl TextDisplay {
     /// This is similar to [`TextDisplay::text_index_nearest`], but allows the
     /// line to be specified explicitly. Returns `None` only on invalid `line`.
     pub fn line_index_nearest(&self, line: usize, x: f32) -> Option<usize> {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
         if line >= self.lines.len() {
             return None;
         }

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -228,9 +228,8 @@ impl TextDisplay {
     /// ```no_run
     /// # use kas_text::{Glyph, Text, Environment};
     /// # fn draw(_: Vec<(f32, Glyph)>) {}
-    /// let env = Environment::default();
-    /// let mut text = Text::new("Some example text");
-    /// text.prepare(&env);
+    /// let mut text = Text::new_single("Some example text");
+    /// text.prepare();
     ///
     /// let mut glyphs = Vec::with_capacity(text.num_glyphs());
     /// text.glyphs(|_, _, height, glyph| glyphs.push((height, glyph)));

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -142,7 +142,7 @@ impl TextDisplay {
     /// The result is also not guaranteed to be within the expected window
     /// between 0 and `self.env().bounds`. The user should clamp the result.
     pub fn text_glyph_pos(&self, index: usize) -> MarkerPosIter {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
 
         let mut v: [MarkerPos; 2] = Default::default();
         let (a, mut b) = (0, 0);
@@ -242,7 +242,7 @@ impl TextDisplay {
     ///
     /// One must call [`TextDisplay::prepare`] before this method.
     pub fn glyphs<F: FnMut(FontId, f32, f32, Glyph)>(&self, mut f: F) {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
 
         // self.wrapped_runs is in logical order
         for run_part in self.wrapped_runs.iter().cloned() {
@@ -284,7 +284,7 @@ impl TextDisplay {
         F: FnMut(FontId, f32, f32, Glyph, usize, X),
         G: FnMut(f32, f32, f32, f32, usize, X),
     {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
         assert!(
             !effects.is_empty(),
             "kas-text::TextDisplay::glyphs_with_effects: effects list is empty"
@@ -457,7 +457,7 @@ impl TextDisplay {
     /// The result is also not guaranteed to be within the expected window
     /// between 0 and `self.env().bounds`. The user should clamp the result.
     pub fn highlight_lines(&self, range: std::ops::Range<usize>) -> Vec<(Vec2, Vec2)> {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
         if range.len() == 0 {
             return vec![];
         }
@@ -548,7 +548,7 @@ impl TextDisplay {
     /// between 0 and `self.env().bounds`. The user should clamp the result.
     #[inline]
     pub fn highlight_runs(&self, range: std::ops::Range<usize>) -> Vec<(Vec2, Vec2)> {
-        assert!(self.action.is_none(), "kas-text::TextDisplay: not ready");
+        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
         if range.len() == 0 {
             return vec![];
         }

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -162,7 +162,7 @@ impl TextDisplay {
                 continue;
             }
 
-            let glyph_run = &self.glyph_runs[to_usize(run_part.glyph_run)];
+            let glyph_run = &self.runs[to_usize(run_part.glyph_run)];
             let sf = fonts().get(glyph_run.font_id).scale_by_dpu(glyph_run.dpu);
 
             // If index is at the end of a run, we potentially get two matches.
@@ -246,7 +246,7 @@ impl TextDisplay {
 
         // self.wrapped_runs is in logical order
         for run_part in self.wrapped_runs.iter().cloned() {
-            let run = &self.glyph_runs[to_usize(run_part.glyph_run)];
+            let run = &self.runs[to_usize(run_part.glyph_run)];
             let font_id = run.font_id;
             let dpu = run.dpu.0;
             let height = run.height;
@@ -308,7 +308,7 @@ impl TextDisplay {
                 continue;
             }
 
-            let run = &self.glyph_runs[to_usize(run_part.glyph_run)];
+            let run = &self.runs[to_usize(run_part.glyph_run)];
             let font_id = run.font_id;
             let dpu = run.dpu.0;
             let height = run.height;
@@ -483,7 +483,7 @@ impl TextDisplay {
                 let mut nearest = 0;
                 let first_run = cur_line.run_range.start();
                 let glyph_run = to_usize(self.wrapped_runs[first_run].glyph_run);
-                if self.glyph_runs[glyph_run].level.is_ltr() {
+                if self.runs[glyph_run].level.is_ltr() {
                     let mut dist = rbound - (rects[0].1).0;
                     for i in 1..rects.len() {
                         let d = rbound - (rects[i].1).0;
@@ -586,7 +586,7 @@ impl TextDisplay {
                 continue;
             }
 
-            let glyph_run = &self.glyph_runs[to_usize(run_part.glyph_run)];
+            let glyph_run = &self.runs[to_usize(run_part.glyph_run)];
             let sf = fonts().get(glyph_run.font_id).scale_by_dpu(glyph_run.dpu);
 
             // else: range.start < to_usize(run_part.text_end)
@@ -615,7 +615,7 @@ impl TextDisplay {
         'a: while i < run_range.end {
             let run_part = &self.wrapped_runs[i];
             let offset = run_part.offset;
-            let glyph_run = &self.glyph_runs[to_usize(run_part.glyph_run)];
+            let glyph_run = &self.runs[to_usize(run_part.glyph_run)];
             let sf = fonts().get(glyph_run.font_id).scale_by_dpu(glyph_run.dpu);
 
             if !first {

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -226,7 +226,7 @@ impl TextDisplay {
     /// glyphs yielded will equal [`TextDisplay::num_glyphs`]. This may be used as
     /// follows:
     /// ```no_run
-    /// # use kas_text::{Glyph, Text, Environment};
+    /// # use kas_text::{Glyph, Text, Environment, TextApi, TextApiExt};
     /// # fn draw(_: Vec<(f32, Glyph)>) {}
     /// let mut text = Text::new_single("Some example text");
     /// text.prepare();

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -226,10 +226,11 @@ impl TextDisplay {
     /// glyphs yielded will equal [`TextDisplay::num_glyphs`]. This may be used as
     /// follows:
     /// ```no_run
-    /// # use kas_text::{Glyph, Text};
+    /// # use kas_text::{Glyph, Text, Environment};
     /// # fn draw(_: Vec<(f32, Glyph)>) {}
-    /// let mut text = Text::new_multi("Some example text");
-    /// text.prepare();
+    /// let env = Environment::default();
+    /// let mut text = Text::new("Some example text");
+    /// text.prepare(&env);
     ///
     /// let mut glyphs = Vec::with_capacity(text.num_glyphs());
     /// text.glyphs(|_, _, height, glyph| glyphs.push((height, glyph)));
@@ -463,7 +464,7 @@ impl TextDisplay {
 
         let mut lines = self.lines.iter();
         let mut rects = Vec::with_capacity(self.lines.len());
-        let rbound = self.env.bounds.0;
+        let rbound = self.width;
 
         // Find the first line
         let mut cur_line = 'l1: loop {

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -45,7 +45,7 @@ pub(crate) struct LineRun {
 }
 
 impl TextDisplay {
-    pub(crate) fn update_run_dpem(&mut self, text: &dyn FormattableText) {
+    pub(crate) fn update_run_dpem<F: FormattableText>(&mut self, text: &F) {
         let mut dpem = self.env.pt_size * self.env.dpp;
 
         let mut font_tokens = text.font_tokens(&self.env);
@@ -73,7 +73,7 @@ impl TextDisplay {
     /// result of splitting and reversing according to Unicode TR9 aka
     /// Bidirectional algorithm), plus a list of "soft break" positions
     /// (where wrapping may introduce new lines depending on available space).
-    pub(crate) fn prepare_runs(&mut self, text: &dyn FormattableText) {
+    pub(crate) fn prepare_runs<F: FormattableText>(&mut self, text: &F) {
         self.runs.clear();
         self.line_runs.clear();
 

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -9,6 +9,7 @@ use super::TextDisplay;
 use crate::conv::{to_u32, to_usize};
 use crate::fonts::FontId;
 use crate::format::FormattableText;
+use crate::Environment;
 use crate::{Direction, Range};
 use smallvec::SmallVec;
 use unicode_bidi::{BidiInfo, Level, LTR_LEVEL, RTL_LEVEL};
@@ -45,10 +46,10 @@ pub(crate) struct LineRun {
 }
 
 impl TextDisplay {
-    pub(crate) fn update_run_dpem<F: FormattableText>(&mut self, text: &F) {
-        let mut dpem = self.env.pt_size * self.env.dpp;
+    pub(crate) fn update_run_dpem<F: FormattableText>(&mut self, text: &F, env: &Environment) {
+        let mut dpem = env.pt_size * env.dpp;
 
-        let mut font_tokens = text.font_tokens(&self.env);
+        let mut font_tokens = text.font_tokens(env);
         let mut next_fmt = font_tokens.next();
 
         for run in &mut self.runs {
@@ -73,14 +74,14 @@ impl TextDisplay {
     /// result of splitting and reversing according to Unicode TR9 aka
     /// Bidirectional algorithm), plus a list of "soft break" positions
     /// (where wrapping may introduce new lines depending on available space).
-    pub(crate) fn prepare_runs<F: FormattableText>(&mut self, text: &F) {
+    pub(crate) fn prepare_runs<F: FormattableText>(&mut self, text: &F, env: &Environment) {
         self.runs.clear();
         self.line_runs.clear();
 
         let mut font_id = FontId::default();
-        let mut dpem = self.env.pt_size * self.env.dpp;
+        let mut dpem = env.pt_size * env.dpp;
 
-        let mut font_tokens = text.font_tokens(&self.env);
+        let mut font_tokens = text.font_tokens(env);
         let mut next_fmt = font_tokens.next();
         if let Some(fmt) = next_fmt.as_ref() {
             if fmt.start == 0 {
@@ -90,8 +91,8 @@ impl TextDisplay {
             }
         }
 
-        let bidi = self.env.bidi;
-        let default_para_level = match self.env.dir {
+        let bidi = env.bidi;
+        let default_para_level = match env.dir {
             Direction::Auto => None,
             Direction::LR => Some(LTR_LEVEL),
             Direction::RL => Some(RTL_LEVEL),

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -49,7 +49,7 @@ impl TextDisplay {
     pub(crate) fn update_run_dpem<F: FormattableText>(&mut self, text: &F, env: &Environment) {
         let mut dpem = env.pt_size * env.dpp;
 
-        let mut font_tokens = text.font_tokens(env);
+        let mut font_tokens = text.font_tokens(env.dpp, env.pt_size);
         let mut next_fmt = font_tokens.next();
 
         for run in &mut self.runs {
@@ -81,7 +81,7 @@ impl TextDisplay {
         let mut font_id = FontId::default();
         let mut dpem = env.pt_size * env.dpp;
 
-        let mut font_tokens = text.font_tokens(env);
+        let mut font_tokens = text.font_tokens(env.dpp, env.pt_size);
         let mut next_fmt = font_tokens.next();
         if let Some(fmt) = next_fmt.as_ref() {
             if fmt.start == 0 {

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -54,14 +54,17 @@ impl TextDisplay {
             }
 
             // This is hacky, but should suffice!
-            let mut soft_breaks = Default::default();
-            std::mem::swap(&mut soft_breaks, &mut run.soft_breaks);
+            let mut breaks = Default::default();
+            std::mem::swap(&mut breaks, &mut run.breaks);
+            if run.level.is_rtl() {
+                breaks.reverse();
+            }
             *run = shaper::shape(
                 text.as_str(),
                 run.range,
                 dpem,
                 run.font_id,
-                soft_breaks,
+                breaks,
                 run.no_break,
                 run.level,
             );
@@ -182,7 +185,7 @@ impl TextDisplay {
                     next_break = breaks_iter.next().unwrap_or((0, false));
                 }
             } else if is_break {
-                breaks.push(to_u32(pos));
+                breaks.push(shaper::GlyphBreak::new(to_u32(pos)));
                 next_break = breaks_iter.next().unwrap_or((0, false));
             }
         }

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -78,7 +78,7 @@ impl TextDisplay {
                     let (part_offset, part_len_no_space, part_len) =
                         run.part_lengths(last_part..part);
                     let line_len = caret + part_len_no_space;
-                    if line_len > width_bound && end.2 > 0 {
+                    if env.wrap && line_len > width_bound && end.2 > 0 {
                         // Add up to last valid break point then wrap and reset
                         let slice = &mut parts[0..end.2];
                         adder.add_line(fonts, level, end_len, &self.glyph_runs, slice, true);

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -67,7 +67,7 @@ impl TextDisplay {
             // Each LineRun contains at least one Run, though a Run may be empty
             let end_index = line.range.end();
             debug_assert!(line.range.start < line.range.end);
-            assert!(end_index <= self.glyph_runs.len());
+            assert!(end_index <= self.runs.len());
             let level = match line.rtl {
                 false => Level::ltr(),
                 true => Level::rtl(),
@@ -82,7 +82,7 @@ impl TextDisplay {
             let mut caret = 0.0;
             let mut index = start.0;
             'a: while index < end_index {
-                let run = &self.glyph_runs[index];
+                let run = &self.runs[index];
                 let num_parts = run.num_parts();
                 let allow_break = !run.no_break; // break allowed at end of run
 
@@ -95,7 +95,7 @@ impl TextDisplay {
                     if wrap && line_len > width_bound && end.2 > 0 {
                         // Add up to last valid break point then wrap and reset
                         let slice = &mut parts[0..end.2];
-                        adder.add_line(fonts, level, end_len, &self.glyph_runs, slice, true);
+                        adder.add_line(fonts, level, end_len, &self.runs, slice, true);
 
                         end.2 = 0;
                         start = end;
@@ -152,7 +152,7 @@ impl TextDisplay {
             if parts.len() > 0 {
                 // It should not be possible for a line to end with a no-break, so:
                 debug_assert_eq!(parts.len(), end.2);
-                adder.add_line(fonts, level, end_len, &self.glyph_runs, &mut parts, false);
+                adder.add_line(fonts, level, end_len, &self.runs, &mut parts, false);
             }
         }
 

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -39,12 +39,12 @@ struct PartInfo {
 }
 
 impl TextDisplay {
-    pub(crate) fn wrap_lines(&mut self) {
+    pub(crate) fn wrap_lines(&mut self, env: &Environment) {
         let fonts = fonts();
         let capacity = 0; // TODO(opt): estimate like self.text_len() / 16 ?
-        let mut adder = LineAdder::new(capacity, &self.env);
+        let mut adder = LineAdder::new(capacity, env);
         let width_bound = adder.width_bound;
-        let justify = self.env.halign == Align::Stretch;
+        let justify = env.halign == Align::Stretch;
         let mut parts = Vec::with_capacity(16);
 
         // Almost everything in "this" method depends on the line direction, so
@@ -142,10 +142,11 @@ impl TextDisplay {
             }
         }
 
-        self.required = adder.finish(self.env.valign, self.env.bounds.1);
+        self.required = adder.finish(env.valign, env.bounds.1);
         self.wrapped_runs = adder.runs;
         self.lines = adder.lines;
         self.num_glyphs = adder.num_glyphs;
+        self.width = env.bounds.0;
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -5,8 +5,6 @@
 
 //! KAS Rich-Text library — text-display enviroment
 
-use crate::display::Action;
-use crate::fonts::{fonts, FontId};
 use crate::Vec2;
 
 /// Environment in which text is prepared for display
@@ -91,98 +89,6 @@ impl Environment {
     /// default font size and zero-sized bounds.
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Returns the height of standard horizontal text
-    ///
-    /// This depends on the `pt_size` and `dpp` fields.
-    ///
-    /// To use "the standard font", use `Default::default()`.
-    pub fn height(&self, font_id: FontId) -> f32 {
-        let dpem = self.pt_size * self.dpp;
-        fonts().get(font_id).height(dpem)
-    }
-}
-
-/// Helper to modify an environment
-#[derive(Debug)]
-pub struct UpdateEnv<'a> {
-    env: &'a mut Environment,
-    action: Action,
-}
-
-impl<'a> UpdateEnv<'a> {
-    pub(crate) fn new(env: &'a mut Environment) -> Self {
-        let action = Action::None;
-        UpdateEnv { env, action }
-    }
-
-    pub(crate) fn finish(self) -> Action {
-        self.action
-    }
-
-    /// Read access to the environment
-    pub fn env(&self) -> &Environment {
-        self.env
-    }
-
-    /// Set DPP
-    ///
-    /// Units are pixels/point (see [`Environment::dpp`]).
-    pub fn set_dpp(&mut self, dpp: f32) {
-        if dpp != self.env.dpp {
-            self.env.dpp = dpp;
-            self.action = Action::Dpem;
-        }
-    }
-
-    /// Set default font size in points
-    ///
-    /// Units are points/em (see [`Environment::pt_size`]).
-    pub fn set_pt_size(&mut self, pt_size: f32) {
-        if pt_size != self.env.pt_size {
-            self.env.pt_size = pt_size;
-            self.action = Action::Dpem;
-        }
-    }
-
-    /// Set the default direction
-    pub fn set_dir(&mut self, dir: Direction) {
-        if dir != self.env.dir {
-            self.env.dir = dir;
-            self.action = Action::Runs;
-        }
-    }
-
-    /// Set the alignment
-    ///
-    /// Takes `(horiz_align, vert_align)` tuple to allow easier parameter passing.
-    pub fn set_align(&mut self, (horiz, vert): (Align, Align)) {
-        if horiz != self.env.halign || vert != self.env.valign {
-            self.env.halign = horiz;
-            self.env.valign = vert;
-            self.action = self.action.max(Action::Wrap);
-        }
-    }
-
-    /// Enable or disable line-wrapping
-    pub fn set_wrap(&mut self, wrap: bool) {
-        if wrap != self.env.wrap {
-            self.env.wrap = wrap;
-            self.action = self.action.max(Action::Wrap);
-        }
-    }
-
-    /// Set the environment's bounds
-    pub fn set_bounds(&mut self, bounds: Vec2) {
-        if bounds != self.env.bounds {
-            // Note (opt): if we had separate align and wrap actions, then we
-            // would only need to do alignment provided:
-            // self.width_required <= bounds.0.min(self.env.bounds.0)
-            // This may not be worth pursuing however.
-            self.env.bounds = bounds;
-            self.action = self.action.max(Action::Wrap);
-        }
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -12,83 +12,89 @@ use crate::Vec2;
 /// An `Environment` can be default-constructed (without line-wrapping).
 #[derive(Clone, Debug, PartialEq)]
 pub struct Environment {
-    /// The available (horizontal and vertical) space
-    ///
-    /// This defaults to infinity (implying no bounds).
-    /// If line-wrapping is enabled, it is controlled by this width.
-    /// Glyphs outside of these bounds may not be drawn.
-    pub bounds: Vec2,
-    /// Pixels-per-point
-    ///
-    /// This is a scaling factor used to convert font sizes (in points) to a
-    /// size in pixels (dots). Units are `pixels/point`.
-    ///
-    /// Since "72 pt = 1 in" and the "standard" DPI is 96, calculate as:
-    /// ```none
-    /// dpp = dpi / 72 = scale_factor * (96 / 72)
-    /// ```
-    ///
-    /// Note that most systems allow the user to adjust the "font DPI" or set a
-    /// scaling factor, thus this value may not correspond to the real pixel
-    /// density of the display.
-    pub dpp: f32,
-    /// Default font size in points
-    ///
-    /// This is stored in units of pt/em partly because this is a standard unit
-    /// and partly because it allows fonts to scale with DPI.
-    pub pt_size: f32,
-    /// Default text direction
-    ///
-    /// Note: right-to-left text can still occur in a left-to-right environment
-    /// and vice-versa, however the default alignment direction can affect the
-    /// layout of complex texts.
-    pub dir: Direction,
     /// Bidirectional text
     ///
     /// If enabled, right-to-left text embedded within left-to-right text and
-    /// RTL within LTR will be re-ordered correctly (up to the maximum embedding
-    /// level defined by Unicode Technical Report #9).
+    /// LTR within RTL will be re-ordered according to the Unicode Bidirectional
+    /// Algorithm (Unicode Technical Report #9).
     ///
     /// If disabled, the base paragraph direction may be LTR or RTL depending on
     /// [`Environment::dir`], but embedded text is not re-ordered.
     ///
-    /// Normally this should be enabled, but within text-editors it might be
-    /// disabled (at user's preference).
+    /// Default value: `true`. This should normally be enabled unless there is
+    /// a specific reason to disable it.
     pub bidi: bool,
-    /// Horizontal alignment
-    pub halign: Align,
-    /// Vertical alignment
-    pub valign: Align,
+    /// Default text direction
+    ///
+    /// Usually this may be left to its default value of [`Direction::Auto`].
+    /// If `bidi == true`, this parameter sets the "paragraph embedding level"
+    /// (whose main affect is on lines without strongly-directional characters).
+    /// If `bidi == false` this directly sets the line direction, unless
+    /// `dir == Auto`, in which case direction is auto-detected.
+    pub dir: Direction,
+    /// Pixels-per-point
+    ///
+    /// This is a scaling factor used to convert font sizes (in points) to a
+    /// size in pixels (dots). Units are `pixels/point`. See [`crate::fonts`]
+    /// documentation.
+    ///
+    /// Default value: `96.0 / 72.0`
+    pub dpp: f32,
+    /// Default font size in points
+    ///
+    /// We use "point sizes" (Points per Em), since this is a widely used
+    /// measure of font size. See [`crate::fonts`] module documentation.
+    ///
+    /// Default value: `11.0`
+    pub pt_size: f32,
+    /// The available (horizontal and vertical) space
+    ///
+    /// This defaults to infinity (implying no bounds). To enable line-wrapping
+    /// set at least a horizontal bound. The vertical bound is required for
+    /// alignment (when aligning to the centre or bottom).
+    /// Glyphs outside of these bounds may not be drawn.
+    pub bounds: Vec2,
     /// Line wrapping
     ///
-    /// If true, text is wrapped at word boundaries to fit within the available
-    /// width (regardless of height). If false, only explicit line-breaks such
-    /// as `\n` result in new lines.
+    /// By default, this is true and long text lines are wrapped based on the
+    /// width bounds. If set to false, lines are not wrapped at the width
+    /// boundary, but explicit line-breaks such as `\n` still result in new
+    /// lines.
     pub wrap: bool,
+    /// Horizontal alignment
+    ///
+    /// By default, horizontal alignment is left or right depending on the
+    /// text direction (see [`Environment::dir`]).
+    pub halign: Align,
+    /// Vertical alignment
+    ///
+    /// By default, vertical alignment is to-the-top.
+    pub valign: Align,
 }
 
 impl Default for Environment {
     fn default() -> Self {
         Environment {
+            bidi: true,
+            dir: Direction::default(),
             dpp: 96.0 / 72.0,
             pt_size: 11.0,
-            dir: Direction::default(),
-            bidi: true,
+            bounds: Vec2::INFINITY,
+            wrap: true,
             halign: Align::default(),
             valign: Align::default(),
-            wrap: true,
-            bounds: Vec2::INFINITY,
         }
     }
 }
 
 impl Environment {
-    /// Alternative default constructor
-    ///
-    /// Has left-to-right direction, default alignment, no line-wrapping,
-    /// default font size and zero-sized bounds.
-    pub fn new() -> Self {
-        Self::default()
+    /// Construct, with explicit font size
+    pub fn new(dpp: f32, pt_size: f32) -> Self {
+        Environment {
+            dpp,
+            pt_size,
+            ..Default::default()
+        }
     }
 }
 
@@ -99,9 +105,8 @@ impl Environment {
 pub enum Align {
     /// Default alignment
     ///
-    /// This is context dependent: for things that want to stretch it means
-    /// stretch, for things which don't it means align-to-start (e.g. to
-    /// top-left for left-to-right text).
+    /// This is context dependent. For example, for Left-To-Right text it means
+    /// `TL`; for things which want to stretch it may mean `Stretch`.
     Default,
     /// Align to top or left
     TL,

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -47,8 +47,9 @@
 //!
 //! Warning: on MacOS and Apple systems, a *point* sometimes refers to a
 //! (virtual) pixel, yielding `dpp = 1` (or `dpp = 2` on Retina screens, or
-//! something else entirely on iPhones). Apple font sizes may therefore be
-//! difficult to compare.
+//! something else entirely on iPhones). On any system, DPI/DPP/scale factor
+//! values may be set according to the user's taste rather than physical
+//! measurements.
 //!
 //! Finally, note that digital font files have an internally defined unit
 //! known as the *font unit*. This is not normally used directly but is used

--- a/src/format.rs
+++ b/src/format.rs
@@ -175,6 +175,6 @@ pub struct FontToken {
     /// Font size, in dots-per-em (pixel width of an 'M')
     ///
     /// This may be calculated from point size as `pt_size * dpp`, where `dpp`
-    /// is the number of pixels per point ([`Environment::dpp`]).
+    /// is the number of pixels per point (see [`crate::fonts`] documentation).
     pub dpem: f32,
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -5,8 +5,10 @@
 
 //! Parsers for formatted text
 
-use crate::env::Environment;
 use crate::fonts::FontId;
+use crate::{Environment, OwningVecIter};
+
+mod plain;
 
 #[cfg(feature = "markdown")]
 mod markdown;
@@ -15,17 +17,21 @@ pub use markdown::Markdown;
 
 /// Text, optionally with formatting data
 ///
-/// Note: this trait always returns a boxed dyn iterator. This allows usage in
-/// non-generic types and carries only a small
-/// usage penalty (since formatting data is not accessed frequently).
-/// To support generating non-dyn iterators would require use of generic
-/// associated types (an unstable nightly feature) to attach the lifetime
-/// restriction on the iterator or unsafe code to ignore it.
+/// Any `F: FormattableText` automatically support [`FormattableTextDyn`].
+/// Implement either this or [`FormattableTextDyn`], not both.
+///
+/// This trait can only be written as intended using Generic Associated Types
+/// ("gat", unstable nightly feature), thus `font_tokens` has a different
+/// signature with/without feature `gat` and the associated type
+/// `FontTokenIterator` is only present with feature `gat`.
 pub trait FormattableText: std::fmt::Debug {
-    /// Produce a boxed clone of self
-    fn clone_boxed(&self) -> Box<dyn FormattableText>;
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "gat")))]
+    #[cfg(feature = "gat")]
+    type FontTokenIterator<'a>: Iterator<Item = FontToken>;
 
     /// Length of text
+    ///
+    /// Default implementation uses [`FormattableText::as_str`].
     #[inline]
     fn str_len(&self) -> usize {
         self.as_str().len()
@@ -40,7 +46,86 @@ pub trait FormattableText: std::fmt::Debug {
     /// increasing; if not, formatting may not be applied correctly.
     ///
     /// For plain text this iterator will be empty.
-    fn font_tokens<'a>(&'a self, env: &'a Environment) -> Box<dyn Iterator<Item = FontToken> + 'a>;
+    #[cfg(feature = "gat")]
+    fn font_tokens<'a>(&'a self, env: &'a Environment) -> Self::FontTokenIterator<'a>;
+
+    /// Construct an iterator over formatting items
+    ///
+    /// It is expected that [`FontToken::start`] of yielded items is strictly
+    /// increasing; if not, formatting may not be applied correctly.
+    ///
+    /// For plain text this iterator will be empty.
+    #[cfg(not(feature = "gat"))]
+    fn font_tokens(&self, env: &Environment) -> OwningVecIter<FontToken>;
+}
+
+/// Text, optionally with formatting data
+///
+/// The type `&dyn FormattableTextDyn` supports [`FormattableText`].
+/// Implement either this or [`FormattableText`], not both.
+pub trait FormattableTextDyn: std::fmt::Debug {
+    /// Produce a boxed clone of self
+    fn clone_boxed(&self) -> Box<dyn FormattableTextDyn>;
+
+    /// Length of text
+    fn str_len(&self) -> usize;
+
+    /// Access whole text as contiguous `str`
+    fn as_str(&self) -> &str;
+
+    /// Construct an iterator over formatting items
+    ///
+    /// It is expected that [`FontToken::start`] of yielded items is strictly
+    /// increasing; if not, formatting may not be applied correctly.
+    ///
+    /// For plain text this iterator will be empty.
+    fn font_tokens(&self, env: &Environment) -> OwningVecIter<FontToken>;
+}
+
+// #[cfg(feature = "gat")]
+impl<F: FormattableText + Clone + 'static> FormattableTextDyn for F {
+    fn clone_boxed(&self) -> Box<dyn FormattableTextDyn> {
+        Box::new(self.clone())
+    }
+
+    fn str_len(&self) -> usize {
+        FormattableText::str_len(self)
+    }
+    fn as_str(&self) -> &str {
+        FormattableText::as_str(self)
+    }
+
+    fn font_tokens(&self, env: &Environment) -> OwningVecIter<FontToken> {
+        let iter = FormattableText::font_tokens(self, env);
+        #[cfg(feature = "gat")]
+        {
+            OwningVecIter::new(iter.collect())
+        }
+        #[cfg(not(feature = "gat"))]
+        {
+            iter
+        }
+    }
+}
+
+impl<'t> FormattableText for &'t dyn FormattableTextDyn {
+    #[cfg(feature = "gat")]
+    type FontTokenIterator<'a> = OwningVecIter<FontToken>;
+
+    #[inline]
+    fn str_len(&self) -> usize {
+        FormattableTextDyn::str_len(*self)
+    }
+
+    #[inline]
+    fn as_str(&self) -> &str {
+        FormattableTextDyn::as_str(*self)
+    }
+
+    #[inline]
+    fn font_tokens(&self, env: &Environment) -> OwningVecIter<FontToken> {
+        FormattableTextDyn::font_tokens(*self, env)
+    }
 }
 
 /// Extension of [`FormattableText`] allowing editing
@@ -71,55 +156,7 @@ pub trait EditableText: FormattableText {
     fn replace_range(&mut self, start: usize, end: usize, replace_with: &str);
 }
 
-impl<'t> FormattableText for &'t str {
-    fn clone_boxed(&self) -> Box<dyn FormattableText> {
-        // TODO(specialization): for 'static we can simply use this:
-        // Box::new(*self)
-        Box::new(self.to_string())
-    }
-
-    fn as_str(&self) -> &str {
-        self
-    }
-
-    fn font_tokens<'a>(&'a self, _: &'a Environment) -> Box<dyn Iterator<Item = FontToken> + 'a> {
-        Box::new(std::iter::empty())
-    }
-}
-
-impl FormattableText for String {
-    fn clone_boxed(&self) -> Box<dyn FormattableText> {
-        Box::new(self.clone())
-    }
-
-    fn as_str(&self) -> &str {
-        self
-    }
-
-    fn font_tokens<'a>(&'a self, _: &'a Environment) -> Box<dyn Iterator<Item = FontToken> + 'a> {
-        Box::new(std::iter::empty())
-    }
-}
-
-impl EditableText for String {
-    fn set_string(&mut self, string: String) {
-        *self = string;
-    }
-
-    fn swap_string(&mut self, string: &mut String) {
-        std::mem::swap(self, string);
-    }
-
-    fn insert_char(&mut self, index: usize, c: char) {
-        self.insert(index, c);
-    }
-
-    fn replace_range(&mut self, start: usize, end: usize, replace_with: &str) {
-        self.replace_range(start..end, replace_with);
-    }
-}
-
-impl Clone for Box<dyn FormattableText> {
+impl Clone for Box<dyn FormattableTextDyn> {
     fn clone(&self) -> Self {
         (**self).clone_boxed()
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -6,7 +6,7 @@
 //! Parsers for formatted text
 
 use crate::fonts::FontId;
-use crate::{Environment, OwningVecIter};
+use crate::OwningVecIter;
 
 mod plain;
 
@@ -45,18 +45,22 @@ pub trait FormattableText: std::fmt::Debug {
     /// It is expected that [`FontToken::start`] of yielded items is strictly
     /// increasing; if not, formatting may not be applied correctly.
     ///
+    /// The `dpp` and `pt_size` parameters are as in [`crate::Environment`].
+    ///
     /// For plain text this iterator will be empty.
     #[cfg(feature = "gat")]
-    fn font_tokens<'a>(&'a self, env: &'a Environment) -> Self::FontTokenIterator<'a>;
+    fn font_tokens<'a>(&'a self, dpp: f32, pt_size: f32) -> Self::FontTokenIterator<'a>;
 
     /// Construct an iterator over formatting items
     ///
     /// It is expected that [`FontToken::start`] of yielded items is strictly
     /// increasing; if not, formatting may not be applied correctly.
     ///
+    /// The `dpp` and `pt_size` parameters are as in [`crate::Environment`].
+    ///
     /// For plain text this iterator will be empty.
     #[cfg(not(feature = "gat"))]
-    fn font_tokens(&self, env: &Environment) -> OwningVecIter<FontToken>;
+    fn font_tokens(&self, dpp: f32, pt_size: f32) -> OwningVecIter<FontToken>;
 }
 
 /// Text, optionally with formatting data
@@ -78,8 +82,10 @@ pub trait FormattableTextDyn: std::fmt::Debug {
     /// It is expected that [`FontToken::start`] of yielded items is strictly
     /// increasing; if not, formatting may not be applied correctly.
     ///
+    /// The `dpp` and `pt_size` parameters are as in [`crate::Environment`].
+    ///
     /// For plain text this iterator will be empty.
-    fn font_tokens(&self, env: &Environment) -> OwningVecIter<FontToken>;
+    fn font_tokens(&self, dpp: f32, pt_size: f32) -> OwningVecIter<FontToken>;
 }
 
 // #[cfg(feature = "gat")]
@@ -95,8 +101,8 @@ impl<F: FormattableText + Clone + 'static> FormattableTextDyn for F {
         FormattableText::as_str(self)
     }
 
-    fn font_tokens(&self, env: &Environment) -> OwningVecIter<FontToken> {
-        let iter = FormattableText::font_tokens(self, env);
+    fn font_tokens(&self, dpp: f32, pt_size: f32) -> OwningVecIter<FontToken> {
+        let iter = FormattableText::font_tokens(self, dpp, pt_size);
         #[cfg(feature = "gat")]
         {
             OwningVecIter::new(iter.collect())
@@ -123,8 +129,8 @@ impl<'t> FormattableText for &'t dyn FormattableTextDyn {
     }
 
     #[inline]
-    fn font_tokens(&self, env: &Environment) -> OwningVecIter<FontToken> {
-        FormattableTextDyn::font_tokens(*self, env)
+    fn font_tokens(&self, dpp: f32, pt_size: f32) -> OwningVecIter<FontToken> {
+        FormattableTextDyn::font_tokens(*self, dpp, pt_size)
     }
 }
 

--- a/src/format/markdown.rs
+++ b/src/format/markdown.rs
@@ -8,7 +8,6 @@
 use super::{EditableText, FontToken, FormattableText};
 use crate::conv::to_u32;
 use crate::fonts::{self, FamilyName, FontId, FontSelector, Style, Weight};
-use crate::Environment;
 #[cfg(not(feature = "gat"))]
 use crate::OwningVecIter;
 use pulldown_cmark::{Event, Tag};
@@ -36,14 +35,14 @@ pub struct FontTokenIter<'a> {
 }
 
 impl<'a> FontTokenIter<'a> {
-    fn new(fmt: &'a [Fmt], env: &Environment) -> Self {
+    fn new(fmt: &'a [Fmt], base_dpem: f32) -> Self {
         FontTokenIter {
             index: 0,
             fmt,
             fonts: fonts::fonts(),
             font_id: FontId::default(),
             font_sel: FontSelector::default(),
-            base_dpem: env.dpp * env.pt_size,
+            base_dpem,
         }
     }
 }
@@ -81,13 +80,13 @@ impl FormattableText for Markdown {
 
     #[cfg(feature = "gat")]
     #[inline]
-    fn font_tokens<'a>(&'a self, env: &Environment) -> Self::FontTokenIterator<'a> {
-        FontTokenIter::new(&self.fmt, env)
+    fn font_tokens<'a>(&'a self, dpp: f32, pt_size: f32) -> Self::FontTokenIterator<'a> {
+        FontTokenIter::new(&self.fmt, dpp * pt_size)
     }
     #[cfg(not(feature = "gat"))]
     #[inline]
-    fn font_tokens(&self, env: &Environment) -> OwningVecIter<FontToken> {
-        let iter = FontTokenIter::new(&self.fmt, env);
+    fn font_tokens(&self, dpp: f32, pt_size: f32) -> OwningVecIter<FontToken> {
+        let iter = FontTokenIter::new(&self.fmt, dpp * pt_size);
         OwningVecIter::new(iter.collect())
     }
 }

--- a/src/format/plain.rs
+++ b/src/format/plain.rs
@@ -1,0 +1,65 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Impls for plain text
+
+use super::{EditableText, FontToken, FormattableText};
+use crate::Environment;
+#[cfg(not(feature = "gat"))]
+use crate::OwningVecIter;
+
+impl<'t> FormattableText for &'t str {
+    #[cfg(feature = "gat")]
+    type FontTokenIterator<'a> = std::iter::Empty<FontToken>;
+
+    fn as_str(&self) -> &str {
+        self
+    }
+
+    #[cfg(feature = "gat")]
+    fn font_tokens<'a>(&'a self, _: &Environment) -> Self::FontTokenIterator<'a> {
+        std::iter::empty()
+    }
+    #[cfg(not(feature = "gat"))]
+    fn font_tokens(&self, _: &Environment) -> OwningVecIter<FontToken> {
+        OwningVecIter::new(Vec::new())
+    }
+}
+
+impl FormattableText for String {
+    #[cfg(feature = "gat")]
+    type FontTokenIterator<'a> = std::iter::Empty<FontToken>;
+
+    fn as_str(&self) -> &str {
+        self
+    }
+
+    #[cfg(feature = "gat")]
+    fn font_tokens<'a>(&'a self, _: &Environment) -> Self::FontTokenIterator<'a> {
+        std::iter::empty()
+    }
+    #[cfg(not(feature = "gat"))]
+    fn font_tokens(&self, _: &Environment) -> OwningVecIter<FontToken> {
+        OwningVecIter::new(Vec::new())
+    }
+}
+
+impl EditableText for String {
+    fn set_string(&mut self, string: String) {
+        *self = string;
+    }
+
+    fn swap_string(&mut self, string: &mut String) {
+        std::mem::swap(self, string);
+    }
+
+    fn insert_char(&mut self, index: usize, c: char) {
+        self.insert(index, c);
+    }
+
+    fn replace_range(&mut self, start: usize, end: usize, replace_with: &str) {
+        self.replace_range(start..end, replace_with);
+    }
+}

--- a/src/format/plain.rs
+++ b/src/format/plain.rs
@@ -6,7 +6,6 @@
 //! Impls for plain text
 
 use super::{EditableText, FontToken, FormattableText};
-use crate::Environment;
 #[cfg(not(feature = "gat"))]
 use crate::OwningVecIter;
 
@@ -19,11 +18,11 @@ impl<'t> FormattableText for &'t str {
     }
 
     #[cfg(feature = "gat")]
-    fn font_tokens<'a>(&'a self, _: &Environment) -> Self::FontTokenIterator<'a> {
+    fn font_tokens<'a>(&'a self, _: f32, _: f32) -> Self::FontTokenIterator<'a> {
         std::iter::empty()
     }
     #[cfg(not(feature = "gat"))]
-    fn font_tokens(&self, _: &Environment) -> OwningVecIter<FontToken> {
+    fn font_tokens(&self, _: f32, _: f32) -> OwningVecIter<FontToken> {
         OwningVecIter::new(Vec::new())
     }
 }
@@ -37,11 +36,11 @@ impl FormattableText for String {
     }
 
     #[cfg(feature = "gat")]
-    fn font_tokens<'a>(&'a self, _: &Environment) -> Self::FontTokenIterator<'a> {
+    fn font_tokens<'a>(&'a self, _: f32, _: f32) -> Self::FontTokenIterator<'a> {
         std::iter::empty()
     }
     #[cfg(not(feature = "gat"))]
-    fn font_tokens(&self, _: &Environment) -> OwningVecIter<FontToken> {
+    fn font_tokens(&self, _: f32, _: f32) -> OwningVecIter<FontToken> {
         OwningVecIter::new(Vec::new())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! KAS Rich-Text library
 
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(feature = "gat", feature(generic_associated_types))]
 
 mod env;
 pub use env::*;
@@ -23,6 +24,9 @@ pub mod format;
 
 mod text;
 pub use text::{Text, TextApi};
+
+mod util;
+pub use util::OwningVecIter;
 
 pub(crate) mod shaper;
 pub use shaper::{Glyph, GlyphId};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod data;
 pub use data::{Range, Vec2};
 
 mod display;
-pub use display::{Effect, EffectFlags, PrepareAction, TextDisplay};
+pub use display::{Effect, EffectFlags, TextDisplay};
 
 pub mod fonts;
 pub mod format;
@@ -26,7 +26,7 @@ mod text;
 pub use text::{Text, TextApi};
 
 mod util;
-pub use util::OwningVecIter;
+pub use util::{Action, OwningVecIter};
 
 pub(crate) mod shaper;
 pub use shaper::{Glyph, GlyphId};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,13 @@ mod data;
 pub use data::{Range, Vec2};
 
 mod display;
-pub use display::{Effect, EffectFlags, TextDisplay};
+pub use display::*;
 
 pub mod fonts;
 pub mod format;
 
 mod text;
-pub use text::{Text, TextApi};
+pub use text::*;
 
 mod util;
 pub use util::{Action, OwningVecIter};

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -19,7 +19,7 @@
 
 use crate::conv::{to_u32, to_usize, DPU};
 use crate::fonts::{fonts, FontId};
-use crate::{display, Range, Vec2};
+use crate::{Range, Vec2};
 use smallvec::SmallVec;
 use unicode_bidi::Level;
 
@@ -60,12 +60,27 @@ pub(crate) struct GlyphBreak {
 /// text, this is the end nearer the origin than `caret`).
 #[derive(Clone, Debug)]
 pub(crate) struct GlyphRun {
+    /// Range in source text
+    pub range: Range,
+    /// Font size (pixels/em)
+    pub dpem: f32,
+    /// Font identifier
+    pub font_id: FontId,
+    /// All soft-break locations within this range (excludes end)
+    ///
+    /// Note: it would be equivalent to use a separate `Run` for each sub-range
+    /// in the text instead of tracking breaks via this field.
+    pub soft_breaks: SmallVec<[u32; 5]>,
+    /// If true, the logical-end of this Run is not a valid break point
+    pub no_break: bool,
+    /// BIDI level
+    pub level: Level,
+
     /// Sequence of all glyphs, in left-to-right order
     pub glyphs: Vec<Glyph>,
     /// Sequence of all break points, in left-to-right order
     pub breaks: SmallVec<[GlyphBreak; 2]>,
 
-    pub font_id: FontId,
     pub dpu: DPU,
     /// Text height in pixels (stored for compat with glyph_brush downstream)
     pub height: f32,
@@ -76,14 +91,6 @@ pub(crate) struct GlyphRun {
     pub no_space_end: f32,
     /// Position of next glyph, if this run is followed by another
     pub caret: f32,
-
-    // TODO: maybe we shouldn't duplicate this information?
-    /// Range of text represented
-    pub range: Range,
-    /// BIDI level (odd levels are right-to-left)
-    pub level: Level,
-    /// If true, the logical-start of this Run is not a valid break point
-    pub no_break: bool,
 }
 
 impl GlyphRun {
@@ -196,22 +203,32 @@ impl GlyphRun {
 /// A "run" is expected to be the maximal sequence of code points of the same
 /// embedding level (as defined by Unicode TR9 aka BIDI algorithm) *and*
 /// excluding all hard line breaks (e.g. `\n`).
-pub(crate) fn shape(text: &str, run: &display::Run) -> GlyphRun {
+pub(crate) fn shape(
+    text: &str,   // contiguous text
+    range: Range, // range in text
+    dpem: f32,
+    font_id: FontId,
+    // All soft-break locations within this run, excluding the end
+    soft_breaks: SmallVec<[u32; 5]>,
+    // If true, the logical-end of this Run is not a valid break point
+    no_break: bool,
+    level: Level,
+) -> GlyphRun {
     let mut glyphs = vec![];
     let mut breaks = Default::default();
     let mut no_space_end = 0.0;
     let mut caret = 0.0;
 
-    let face = fonts().get(run.font_id);
-    let dpu = face.dpu(run.dpem);
+    let face = fonts().get(font_id);
+    let dpu = face.dpu(dpem);
     let sf = face.scale_by_dpu(dpu);
 
-    if run.dpem >= 0.0 {
+    if dpem >= 0.0 {
         #[cfg(feature = "harfbuzz_rs")]
-        let r = shape_harfbuzz(text, run);
+        let r = shape_harfbuzz(text, range, dpem, font_id, level, &soft_breaks);
 
         #[cfg(not(feature = "harfbuzz_rs"))]
-        let r = shape_simple(sf, text, run);
+        let r = shape_simple(sf, text, range, level, &soft_breaks);
 
         glyphs = r.0;
         breaks = r.1;
@@ -219,7 +236,7 @@ pub(crate) fn shape(text: &str, run: &display::Run) -> GlyphRun {
         caret = r.3;
     }
 
-    if run.level.is_rtl() {
+    if level.is_rtl() {
         // With RTL text, no_space_end means start_no_space; recalculate
         let mut break_i = breaks.len().wrapping_sub(1);
         let mut start_no_space = caret;
@@ -246,16 +263,19 @@ pub(crate) fn shape(text: &str, run: &display::Run) -> GlyphRun {
     }
 
     GlyphRun {
+        range,
+        dpem,
+        font_id,
+        soft_breaks,
+        no_break,
+        level,
+
         glyphs,
         breaks,
-        font_id: run.font_id,
         dpu,
         height: sf.height(),
         no_space_end,
         caret,
-        range: run.range,
-        level: run.level,
-        no_break: run.no_break,
     }
 }
 
@@ -263,10 +283,14 @@ pub(crate) fn shape(text: &str, run: &display::Run) -> GlyphRun {
 #[cfg(feature = "harfbuzz_rs")]
 fn shape_harfbuzz(
     text: &str,
-    run: &display::Run,
+    range: Range,
+    dpem: f32,
+    font_id: FontId,
+    level: Level,
+    soft_breaks: &[u32],
 ) -> (Vec<Glyph>, SmallVec<[GlyphBreak; 2]>, f32, f32) {
-    let dpem = run.dpem;
-    let mut font = fonts().get_harfbuzz(run.font_id);
+    let dpem = dpem;
+    let mut font = fonts().get_harfbuzz(font_id);
 
     // ppem affects hinting but does not scale layout, so this has little effect:
     font.set_ppem(dpem as u32, dpem as u32);
@@ -277,9 +301,9 @@ fn shape_harfbuzz(
     // This is the default: font.set_scale(upem, upem);
     let unit_factor = dpem / (upem as f32);
 
-    let slice = &text[run.range];
-    let idx_offset = run.range.start;
-    let rtl = run.level.is_rtl();
+    let slice = &text[range];
+    let idx_offset = range.start;
+    let rtl = level.is_rtl();
 
     // TODO: cache the buffer for reuse later?
     let buffer = harfbuzz_rs::UnicodeBuffer::new()
@@ -297,14 +321,14 @@ fn shape_harfbuzz(
     let mut caret = 0.0;
     let mut no_space_end = caret;
 
-    let mut breaks_iter = run.breaks.iter();
+    let mut breaks_iter = soft_breaks.iter();
     let mut get_next_break = || match rtl {
         false => breaks_iter.next().cloned().unwrap_or(u32::MAX),
         true => breaks_iter.next_back().cloned().unwrap_or(u32::MAX),
     };
     let mut next_break = get_next_break();
     assert!(next_break >= idx_offset);
-    let mut breaks = SmallVec::<[GlyphBreak; 2]>::with_capacity(run.breaks.len());
+    let mut breaks = SmallVec::<[GlyphBreak; 2]>::with_capacity(soft_breaks.len());
 
     let mut glyphs = Vec::with_capacity(output.len());
 
@@ -352,26 +376,28 @@ fn shape_harfbuzz(
 fn shape_simple(
     sf: crate::fonts::ScaledFaceRef,
     text: &str,
-    run: &display::Run,
+    range: Range,
+    level: Level,
+    soft_breaks: &[u32],
 ) -> (Vec<Glyph>, SmallVec<[GlyphBreak; 2]>, f32, f32) {
     use unicode_bidi_mirroring::get_mirrored;
 
-    let slice = &text[run.range];
-    let idx_offset = run.range.start;
-    let rtl = run.level.is_rtl();
+    let slice = &text[range];
+    let idx_offset = range.start;
+    let rtl = level.is_rtl();
 
     let mut caret = 0.0;
     let mut no_space_end = caret;
     let mut prev_glyph_id: Option<GlyphId> = None;
 
-    let mut breaks_iter = run.breaks.iter();
+    let mut breaks_iter = soft_breaks.iter();
     let mut get_next_break = || match rtl {
         false => breaks_iter.next().cloned().unwrap_or(u32::MAX),
         true => breaks_iter.next_back().cloned().unwrap_or(u32::MAX),
     };
     let mut next_break = get_next_break();
     assert!(next_break >= idx_offset);
-    let mut breaks = SmallVec::<[GlyphBreak; 2]>::with_capacity(run.breaks.len());
+    let mut breaks = SmallVec::<[GlyphBreak; 2]>::with_capacity(soft_breaks.len());
 
     // Allocate with an over-estimate and shrink later:
     let mut glyphs = Vec::with_capacity(slice.len());

--- a/src/text.rs
+++ b/src/text.rs
@@ -12,7 +12,7 @@ use crate::display::{Effect, MarkerPosIter, TextDisplay};
 use crate::fonts::FontId;
 use crate::format::{EditableText, FormattableText};
 use crate::{Action, Glyph, Vec2};
-use crate::{Environment, UpdateEnv};
+use crate::{EnvFlags, Environment, UpdateEnv};
 
 /// Text, prepared for display in a given enviroment
 ///
@@ -51,7 +51,7 @@ impl<T: FormattableText> Text<T> {
     #[inline]
     pub fn new_single(text: T) -> Self {
         let mut env = Environment::default();
-        env.wrap = false;
+        env.flags.remove(EnvFlags::WRAP);
         Self::new(env, text)
     }
 
@@ -241,7 +241,7 @@ impl<T: FormattableText> Text<T> {
     pub fn prepare_runs(&mut self) {
         self.display.prepare_runs(
             &self.text,
-            self.env.bidi,
+            self.env.flags.contains(EnvFlags::BIDI),
             self.env.dir,
             self.env.dpp,
             self.env.pt_size,
@@ -264,8 +264,9 @@ impl<T: FormattableText> Text<T> {
     /// environment state.
     #[inline]
     pub fn prepare_lines(&mut self) -> Vec2 {
+        let wrap = self.env.flags.contains(EnvFlags::WRAP);
         self.display
-            .prepare_lines(self.env.bounds, self.env.wrap, self.env.align)
+            .prepare_lines(self.env.bounds, wrap, self.env.align)
     }
 
     /// Get the number of lines

--- a/src/text.rs
+++ b/src/text.rs
@@ -38,7 +38,7 @@ impl<T: FormattableText> Text<T> {
     pub fn new(text: T) -> Self {
         Text {
             text: text,
-            display: TextDisplay::new(),
+            display: TextDisplay::default(),
         }
     }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -6,7 +6,6 @@
 //! Text object
 
 use std::convert::{AsMut, AsRef};
-use std::ops::Bound;
 
 use crate::display::{Effect, MarkerPosIter, TextDisplay};
 use crate::fonts::FontId;
@@ -16,9 +15,11 @@ use crate::{EnvFlags, Environment, UpdateEnv};
 
 /// Text, prepared for display in a given enviroment
 ///
-/// This struct is composed of two parts: a representation of the text being
-/// displayed, and a [`TextDisplay`] object.
-/// See also documentation of [`TextDisplay`].
+/// This struct is composed of three parts: an [`Environment`], a representation
+/// of the [`FormattableText`] being displayed, and a [`TextDisplay`] object.
+///
+/// Most Functionality is implemented via the [`TextApi`] and [`TextApiExt`]
+/// traits.
 #[derive(Clone, Debug)]
 pub struct Text<T: FormattableText> {
     env: Environment,
@@ -63,28 +64,6 @@ impl<T: FormattableText> Text<T> {
         Self::new(Environment::default(), text)
     }
 
-    /// Read the environment
-    #[inline]
-    pub fn env(&self) -> &Environment {
-        &self.env
-    }
-
-    /// Update the environment and prepare, returning required size
-    ///
-    /// This prepares text as necessary. It always performs line-wrapping.
-    #[inline]
-    pub fn update_env<F: FnOnce(&mut UpdateEnv)>(&mut self, f: F) -> Vec2 {
-        let mut update = UpdateEnv::new(&mut self.env);
-        f(&mut update);
-        let action = update.finish().max(self.display.action);
-        match action {
-            Action::All => self.prepare_runs(),
-            Action::Resize => self.resize_runs(),
-            _ => (),
-        }
-        self.prepare_lines()
-    }
-
     /// Clone the formatted text
     pub fn clone_text(&self) -> T
     where
@@ -97,30 +76,6 @@ impl<T: FormattableText> Text<T> {
     #[inline]
     pub fn take_text(self) -> T {
         self.text
-    }
-
-    /// Clone the unformatted text as a `String`
-    pub fn clone_string(&self) -> String {
-        self.text.as_str().to_string()
-    }
-
-    /// Access to the contiguous text
-    ///
-    /// This is the contiguous text without formatting information.
-    #[inline]
-    pub fn as_str(&self) -> &str {
-        self.text.as_str()
-    }
-
-    /// Length of contiguous text
-    ///
-    /// This is a shortcut to `self.as_str().len()`.
-    ///
-    /// It is valid to reference text within the range `0..text_len()`,
-    /// even if not all text within this range will be displayed (due to runs).
-    #[inline]
-    pub fn str_len(&self) -> usize {
-        self.as_str().len()
     }
 
     /// Access the formattable text object
@@ -144,7 +99,267 @@ impl<T: FormattableText> Text<T> {
     }
 }
 
-impl<T: EditableText> Text<T> {
+/// Trait over a sub-set of [`Text`] functionality
+///
+/// This allows dynamic dispatch over [`Text`]'s type parameters.
+pub trait TextApi {
+    /// Length of text
+    ///
+    /// This is a shortcut to `self.as_str().len()`.
+    ///
+    /// It is valid to reference text within the range `0..text_len()`,
+    /// even if not all text within this range will be displayed (due to runs).
+    #[inline]
+    fn str_len(&self) -> usize {
+        self.as_str().len()
+    }
+
+    /// Access whole text as contiguous `str`
+    ///
+    /// It is valid to reference text within the range `0..text_len()`,
+    /// even if not all text within this range will be displayed (due to runs).
+    fn as_str(&self) -> &str;
+
+    /// Clone the unformatted text as a `String`
+    fn clone_string(&self) -> String;
+
+    /// Read the environment
+    fn env(&self) -> &Environment;
+
+    /// Mutate the environment
+    ///
+    /// If using this directly, ensure that necessary preparation actions are
+    /// completed afterwards. Consider using [`TextApi::update_env`] instead.
+    fn env_mut(&mut self) -> &mut Environment;
+
+    /// Read the [`TextDisplay`]
+    fn display(&self) -> &TextDisplay;
+
+    /// Require an action
+    ///
+    /// Wraps [`TextDisplay::require_action`].
+    fn require_action(&mut self, action: Action);
+
+    /// Prepare text for display
+    ///
+    /// Wraps [`TextDisplay::prepare`], passing through `env`.
+    fn prepare(&mut self);
+
+    /// Prepare text runs
+    ///
+    /// Wraps [`TextDisplay::prepare_runs`], passing parameters from the
+    /// environment state.
+    fn prepare_runs(&mut self);
+
+    /// Update font size
+    ///
+    /// Wraps [`TextDisplay::resize_runs`], passing parameters from the
+    /// environment state.
+    fn resize_runs(&mut self);
+
+    /// Prepare lines ("wrap")
+    ///
+    /// Wraps [`TextDisplay::prepare_lines`], passing parameters from the
+    /// environment state.
+    fn prepare_lines(&mut self) -> Vec2;
+}
+
+impl<T: FormattableText> TextApi for Text<T> {
+    #[inline]
+    fn display(&self) -> &TextDisplay {
+        &self.display
+    }
+
+    #[inline]
+    fn as_str(&self) -> &str {
+        self.text.as_str()
+    }
+
+    #[inline]
+    fn clone_string(&self) -> String {
+        self.text.as_str().to_string()
+    }
+
+    #[inline]
+    fn env(&self) -> &Environment {
+        &self.env
+    }
+
+    #[inline]
+    fn env_mut(&mut self) -> &mut Environment {
+        &mut self.env
+    }
+
+    #[inline]
+    fn require_action(&mut self, action: Action) {
+        self.display.require_action(action);
+    }
+
+    #[inline]
+    fn prepare(&mut self) {
+        self.display.prepare(&self.text, &self.env);
+    }
+
+    #[inline]
+    fn prepare_runs(&mut self) {
+        self.display.prepare_runs(
+            &self.text,
+            self.env.flags.contains(EnvFlags::BIDI),
+            self.env.dir,
+            self.env.dpp,
+            self.env.pt_size,
+        );
+    }
+
+    #[inline]
+    fn resize_runs(&mut self) {
+        self.display
+            .resize_runs(&self.text, self.env.dpp, self.env.pt_size);
+    }
+
+    #[inline]
+    fn prepare_lines(&mut self) -> Vec2 {
+        let wrap = self.env.flags.contains(EnvFlags::WRAP);
+        self.display
+            .prepare_lines(self.env.bounds, wrap, self.env.align)
+    }
+}
+
+/// Extension trait over [`TextApi`]
+pub trait TextApiExt: TextApi {
+    /// Update the environment and prepare, returning required size
+    ///
+    /// This prepares text as necessary. It always performs line-wrapping.
+    fn update_env<F: FnOnce(&mut UpdateEnv)>(&mut self, f: F) -> Vec2 {
+        let mut update = UpdateEnv::new(self.env_mut());
+        f(&mut update);
+        let action = update.finish().max(self.display().action);
+        match action {
+            Action::All => self.prepare_runs(),
+            Action::Resize => self.resize_runs(),
+            _ => (),
+        }
+        self.prepare_lines()
+    }
+
+    /// Get required action
+    #[inline]
+    fn required_action(&self) -> Action {
+        self.display().action
+    }
+
+    /// Get the number of lines
+    ///
+    /// Wraps [`TextDisplay::num_lines`].
+    #[inline]
+    fn num_lines(&self) -> usize {
+        self.display().num_lines()
+    }
+
+    /// Find the line containing text `index`
+    ///
+    /// Wraps [`TextDisplay::find_line`].
+    #[inline]
+    fn find_line(&self, index: usize) -> Option<(usize, std::ops::Range<usize>)> {
+        self.display().find_line(index)
+    }
+
+    /// Get the range of a line, by line number
+    ///
+    /// Wraps [`TextDisplay::line_range`].
+    #[inline]
+    fn line_range(&self, line: usize) -> Option<std::ops::Range<usize>> {
+        self.display().line_range(line)
+    }
+
+    /// Get the directionality of the current line
+    ///
+    /// Wraps [`TextDisplay::line_is_ltr`].
+    #[inline]
+    fn line_is_ltr(&self, line: usize) -> bool {
+        self.display().line_is_ltr(line)
+    }
+
+    /// Get the directionality of the current line
+    ///
+    /// Wraps [`TextDisplay::line_is_rtl`].
+    #[inline]
+    fn line_is_rtl(&self, line: usize) -> bool {
+        self.display().line_is_rtl(line)
+    }
+
+    /// Find the text index for the glyph nearest the given `pos`
+    ///
+    /// Wraps [`TextDisplay::text_index_nearest`].
+    #[inline]
+    fn text_index_nearest(&self, pos: Vec2) -> usize {
+        self.display().text_index_nearest(pos)
+    }
+
+    /// Find the text index nearest horizontal-coordinate `x` on `line`
+    ///
+    /// Wraps [`TextDisplay::line_index_nearest`].
+    #[inline]
+    fn line_index_nearest(&self, line: usize, x: f32) -> Option<usize> {
+        self.display().line_index_nearest(line, x)
+    }
+
+    /// Find the starting position (top-left) of the glyph at the given index
+    ///
+    /// Wraps [`TextDisplay::text_glyph_pos`].
+    fn text_glyph_pos(&self, index: usize) -> MarkerPosIter {
+        self.display().text_glyph_pos(index)
+    }
+
+    /// Get the number of glyphs
+    ///
+    /// Wraps [`TextDisplay::num_glyphs`].
+    #[inline]
+    fn num_glyphs(&self) -> usize {
+        self.display().num_glyphs()
+    }
+
+    /// Yield a sequence of positioned glyphs
+    ///
+    /// Wraps [`TextDisplay::glyphs`].
+    fn glyphs<F: FnMut(FontId, f32, f32, Glyph)>(&self, f: F) {
+        self.display().glyphs(f)
+    }
+
+    /// Like [`TextDisplay::glyphs`] but with added effects
+    ///
+    /// Wraps [`TextDisplay::glyphs_with_effects`].
+    fn glyphs_with_effects<X, F, G>(&self, effects: &[Effect<X>], f: F, g: G)
+    where
+        X: Copy + Default,
+        F: FnMut(FontId, f32, f32, Glyph, usize, X),
+        G: FnMut(f32, f32, f32, f32, usize, X),
+    {
+        self.display().glyphs_with_effects(effects, f, g)
+    }
+
+    /// Yield a sequence of rectangles to highlight a given range, by lines
+    ///
+    /// Wraps [`TextDisplay::highlight_lines`].
+    fn highlight_lines(&self, range: std::ops::Range<usize>) -> Vec<(Vec2, Vec2)> {
+        self.display().highlight_lines(range)
+    }
+
+    /// Yield a sequence of rectangles to highlight a given range, by runs
+    ///
+    /// Wraps [`TextDisplay::highlight_runs`].
+    #[inline]
+    fn highlight_runs(&self, range: std::ops::Range<usize>) -> Vec<(Vec2, Vec2)> {
+        self.display().highlight_runs(range)
+    }
+}
+
+impl<T: TextApi + ?Sized> TextApiExt for T {}
+
+/// Trait over a sub-set of [`Text`] functionality for editable text
+///
+/// This allows dynamic dispatch over [`Text`]'s type parameters.
+pub trait EditableTextApi {
     /// Insert a char at the given position
     ///
     /// This may be used to edit the raw text instead of replacing it.
@@ -155,15 +370,14 @@ impl<T: EditableText> Text<T> {
     ///
     /// Currently this is not significantly more efficent than
     /// [`Text::set_text`]. This may change in the future (TODO).
-    pub fn insert_char(&mut self, index: usize, c: char) {
-        self.text.insert_char(index, c);
-        self.display.action = Action::All;
-    }
+    fn insert_char(&mut self, index: usize, c: char);
 
     /// Replace a section of text
     ///
     /// This may be used to edit the raw text instead of replacing it.
     /// One must call [`Text::prepare`] afterwards.
+    ///
+    /// One may simulate an unbounded range by via `start..usize::MAX`.
     ///
     /// Formatting is adjusted: any specifiers within the replaced text are
     /// pushed back to the end of the replacement, and the position of any
@@ -171,34 +385,14 @@ impl<T: EditableText> Text<T> {
     ///
     /// Currently this is not significantly more efficent than
     /// [`Text::set_text`]. This may change in the future (TODO).
-    #[inline]
-    pub fn replace_range<R>(&mut self, range: R, replace_with: &str)
-    where
-        R: std::ops::RangeBounds<usize> + std::iter::ExactSizeIterator + Clone,
-    {
-        let start = match range.start_bound() {
-            Bound::Included(x) => *x,
-            Bound::Excluded(x) => *x + 1,
-            Bound::Unbounded => 0,
-        };
-        let end = match range.end_bound() {
-            Bound::Included(x) => *x + 1,
-            Bound::Excluded(x) => *x,
-            Bound::Unbounded => usize::MAX,
-        };
-        self.text.replace_range(start, end, replace_with);
-        self.display.action = Action::All;
-    }
+    fn replace_range(&mut self, range: std::ops::Range<usize>, replace_with: &str);
 
     /// Set text to a raw `String`
     ///
     /// One must call [`Text::prepare`] afterwards.
     ///
     /// All existing text formatting is removed.
-    pub fn set_string(&mut self, string: String) {
-        self.text.set_string(string);
-        self.display.action = Action::All;
-    }
+    fn set_string(&mut self, string: String);
 
     /// Swap the raw text with a `String`
     ///
@@ -209,192 +403,33 @@ impl<T: EditableText> Text<T> {
     ///
     /// Currently this is not significantly more efficent than
     /// [`Text::set_text`]. This may change in the future (TODO).
-    pub fn swap_string(&mut self, string: &mut String) {
-        self.text.swap_string(string);
+    fn swap_string(&mut self, string: &mut String);
+}
+
+impl<T: EditableText> EditableTextApi for Text<T> {
+    #[inline]
+    fn insert_char(&mut self, index: usize, c: char) {
+        self.text.insert_char(index, c);
         self.display.action = Action::All;
     }
-}
 
-/// Wrappers around [`TextDisplay`] methods
-impl<T: FormattableText> Text<T> {
-    /// Require an action
-    ///
-    /// Wraps [`TextDisplay::require_action`].
     #[inline]
-    pub fn require_action(&mut self, action: Action) {
-        self.display.require_action(action);
+    fn replace_range(&mut self, range: std::ops::Range<usize>, replace_with: &str) {
+        self.text
+            .replace_range(range.start, range.end, replace_with);
+        self.display.action = Action::All;
     }
 
-    /// Prepare text for display
-    ///
-    /// Wraps [`TextDisplay::prepare`], passing through `env`.
     #[inline]
-    pub fn prepare(&mut self) {
-        self.display.prepare(&self.text, &self.env);
+    fn set_string(&mut self, string: String) {
+        self.text.set_string(string);
+        self.display.action = Action::All;
     }
 
-    /// Prepare text runs
-    ///
-    /// Wraps [`TextDisplay::prepare_runs`], passing parameters from the
-    /// environment state.
     #[inline]
-    pub fn prepare_runs(&mut self) {
-        self.display.prepare_runs(
-            &self.text,
-            self.env.flags.contains(EnvFlags::BIDI),
-            self.env.dir,
-            self.env.dpp,
-            self.env.pt_size,
-        );
-    }
-
-    /// Update font size
-    ///
-    /// Wraps [`TextDisplay::resize_runs`], passing parameters from the
-    /// environment state.
-    #[inline]
-    pub fn resize_runs(&mut self) {
-        self.display
-            .resize_runs(&self.text, self.env.dpp, self.env.pt_size);
-    }
-
-    /// Prepare lines ("wrap")
-    ///
-    /// Wraps [`TextDisplay::prepare_lines`], passing parameters from the
-    /// environment state.
-    #[inline]
-    pub fn prepare_lines(&mut self) -> Vec2 {
-        let wrap = self.env.flags.contains(EnvFlags::WRAP);
-        self.display
-            .prepare_lines(self.env.bounds, wrap, self.env.align)
-    }
-
-    /// Get the number of lines
-    ///
-    /// Wraps [`TextDisplay::num_lines`].
-    #[inline]
-    pub fn num_lines(&self) -> usize {
-        self.display.num_lines()
-    }
-
-    /// Find the line containing text `index`
-    ///
-    /// Wraps [`TextDisplay::find_line`].
-    #[inline]
-    pub fn find_line(&self, index: usize) -> Option<(usize, std::ops::Range<usize>)> {
-        self.display.find_line(index)
-    }
-
-    /// Get the range of a line, by line number
-    ///
-    /// Wraps [`TextDisplay::line_range`].
-    #[inline]
-    pub fn line_range(&self, line: usize) -> Option<std::ops::Range<usize>> {
-        self.display.line_range(line)
-    }
-
-    /// Get the directionality of the current line
-    ///
-    /// Wraps [`TextDisplay::line_is_ltr`].
-    #[inline]
-    pub fn line_is_ltr(&self, line: usize) -> bool {
-        self.display.line_is_ltr(line)
-    }
-
-    /// Get the directionality of the current line
-    ///
-    /// Wraps [`TextDisplay::line_is_rtl`].
-    #[inline]
-    pub fn line_is_rtl(&self, line: usize) -> bool {
-        self.display.line_is_rtl(line)
-    }
-
-    /// Find the text index for the glyph nearest the given `pos`
-    ///
-    /// Wraps [`TextDisplay::text_index_nearest`].
-    #[inline]
-    pub fn text_index_nearest(&self, pos: Vec2) -> usize {
-        self.display.text_index_nearest(pos)
-    }
-
-    /// Find the text index nearest horizontal-coordinate `x` on `line`
-    ///
-    /// Wraps [`TextDisplay::line_index_nearest`].
-    #[inline]
-    pub fn line_index_nearest(&self, line: usize, x: f32) -> Option<usize> {
-        self.display.line_index_nearest(line, x)
-    }
-
-    /// Find the starting position (top-left) of the glyph at the given index
-    ///
-    /// Wraps [`TextDisplay::text_glyph_pos`].
-    pub fn text_glyph_pos(&self, index: usize) -> MarkerPosIter {
-        self.display.text_glyph_pos(index)
-    }
-
-    /// Get the number of glyphs
-    ///
-    /// Wraps [`TextDisplay::num_glyphs`].
-    #[inline]
-    pub fn num_glyphs(&self) -> usize {
-        self.display.num_glyphs()
-    }
-
-    /// Yield a sequence of positioned glyphs
-    ///
-    /// Wraps [`TextDisplay::glyphs`].
-    pub fn glyphs<F: FnMut(FontId, f32, f32, Glyph)>(&self, f: F) {
-        self.display.glyphs(f)
-    }
-
-    /// Like [`TextDisplay::glyphs`] but with added effects
-    ///
-    /// Wraps [`TextDisplay::glyphs_with_effects`].
-    pub fn glyphs_with_effects<X, F, G>(&self, effects: &[Effect<X>], f: F, g: G)
-    where
-        X: Copy + Default,
-        F: FnMut(FontId, f32, f32, Glyph, usize, X),
-        G: FnMut(f32, f32, f32, f32, usize, X),
-    {
-        self.display.glyphs_with_effects(effects, f, g)
-    }
-
-    /// Yield a sequence of rectangles to highlight a given range, by lines
-    ///
-    /// Wraps [`TextDisplay::highlight_lines`].
-    pub fn highlight_lines(&self, range: std::ops::Range<usize>) -> Vec<(Vec2, Vec2)> {
-        self.display.highlight_lines(range)
-    }
-
-    /// Yield a sequence of rectangles to highlight a given range, by runs
-    ///
-    /// Wraps [`TextDisplay::highlight_runs`].
-    #[inline]
-    pub fn highlight_runs(&self, range: std::ops::Range<usize>) -> Vec<(Vec2, Vec2)> {
-        self.display.highlight_runs(range)
-    }
-}
-
-/// Trait over a sub-set of [`Text`] functionality
-///
-/// This allows dynamic dispatch over [`Text`]'s type parameters.
-pub trait TextApi {
-    /// Read the [`TextDisplay`]
-    fn display(&self) -> &TextDisplay;
-
-    /// Prepare text for display
-    ///
-    /// Calls [`TextDisplay::prepare`], passing through `env`.
-    fn prepare(&mut self, env: &Environment);
-}
-
-impl<T: FormattableText> TextApi for Text<T> {
-    fn display(&self) -> &TextDisplay {
-        &self.display
-    }
-
-    fn prepare(&mut self, env: &Environment) {
-        self.display.prepare(&self.text, env);
+    fn swap_string(&mut self, string: &mut String) {
+        self.text.swap_string(string);
+        self.display.action = Action::All;
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Utility types and traits
+
+/// An iterator over a `Vec` which clones elements
+pub struct OwningVecIter<T: Clone> {
+    v: Vec<T>,
+    i: usize,
+}
+
+impl<T: Clone> OwningVecIter<T> {
+    /// Construct from a `Vec`
+    pub fn new(v: Vec<T>) -> Self {
+        let i = 0;
+        OwningVecIter { v, i }
+    }
+}
+
+impl<T: Clone> Iterator for OwningVecIter<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i < self.v.len() {
+            let item = self.v[self.i].clone();
+            self.i += 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,6 +5,27 @@
 
 //! Utility types and traits
 
+/// Describes required text-preparation actions
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub enum Action {
+    /// Nothing to do
+    None,
+    /// Do wrapping and alignment
+    Wrap,
+    /// Resize text, and above
+    Resize,
+    /// Break text into runs, associate fonts, and above
+    All,
+}
+
+impl Action {
+    /// True if action is `Action::None`
+    #[inline]
+    pub fn is_ready(&self) -> bool {
+        *self == Action::None
+    }
+}
+
 /// An iterator over a `Vec` which clones elements
 pub struct OwningVecIter<T: Clone> {
     v: Vec<T>,


### PR DESCRIPTION
Lots of revisions to make things more modular and one fix:

- allow wrap to be turned off
- move `Environment` from `TextDisplay` up to `Text`
- merge  `TextDisplay::runs` and `glyph_runs` fields
- add TextApiExt and EditableTextApi traits
- adjust `FormattableText::font_tokens` to take only `dpp` and `pt_size` parameters
- improve fonts module documentation