### PR TITLE
Add default_aux parameter to TextDisplay::glyphs_with_effects

### DIFF
--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -223,8 +223,10 @@ impl TextDisplay {
     /// Yield a sequence of positioned glyphs
     ///
     /// Glyphs are yielded in undefined order by a call to `f`. The number of
-    /// glyphs yielded will equal [`TextDisplay::num_glyphs`]. This may be used as
-    /// follows:
+    /// glyphs yielded will equal [`TextDisplay::num_glyphs`]. The closure `f`
+    /// receives parameters `font_id, dpu, height, glyph`.
+    ///
+    /// This may be used as follows:
     /// ```no_run
     /// # use kas_text::{Glyph, Text, Environment, TextApi, TextApiExt};
     /// # fn draw(_: Vec<(f32, Glyph)>) {}
@@ -259,7 +261,7 @@ impl TextDisplay {
 
     /// Like [`TextDisplay::glyphs`] but with added effects
     ///
-    /// If the list `effects` is empty or has have first entry with `start > 0`,
+    /// If the list `effects` is empty or has first entry with `start > 0`,
     /// a default-constructed `Effect<X>` token is used.
     /// The user payload `X` is simply passed
     /// through to `f` and `g` calls and may be useful for colour information.

--- a/src/text.rs
+++ b/src/text.rs
@@ -349,13 +349,14 @@ pub trait TextApiExt: TextApi {
     /// Like [`TextDisplay::glyphs`] but with added effects
     ///
     /// Wraps [`TextDisplay::glyphs_with_effects`].
-    fn glyphs_with_effects<X, F, G>(&self, effects: &[Effect<X>], f: F, g: G)
+    fn glyphs_with_effects<X, F, G>(&self, effects: &[Effect<X>], default_aux: X, f: F, g: G)
     where
-        X: Copy + Default,
+        X: Copy,
         F: FnMut(FontId, f32, f32, Glyph, usize, X),
         G: FnMut(f32, f32, f32, f32, usize, X),
     {
-        self.display().glyphs_with_effects(effects, f, g)
+        self.display()
+            .glyphs_with_effects(effects, default_aux, f, g)
     }
 
     /// Yield a sequence of rectangles to highlight a given range, by lines


### PR DESCRIPTION
Breaking change; removes the `X: Default` bound on the `Effect` token auxilliary type.