### PR TITLE
Font fallbacks: lists and per-char selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ gat = []
 
 [dependencies]
 bitflags = "1.2.1"
-fontdb = "0.5.1"
+fontdb = "0.5.4"
 ttf-parser = "0.12.0"
 lazy_static = "1.4.0"
 smallvec = "1.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ repository = "https://github.com/kas-gui/kas-text"
 exclude = ["design"]
 
 [features]
-# Enable shaping. Prefer to depend on "shaping" since we may replace harfbuzz_rs.
-shaping = ["harfbuzz_rs"]
+# Enable shaping with the default dependency.
+shaping = ["rustybuzz"]
+# Enable shaping via HarfBuzz.
+harfbuzz = ["harfbuzz_rs"]
 
 # Enable Markdown parsing
 markdown = ["pulldown-cmark"]
@@ -34,6 +36,10 @@ unicode-bidi-mirroring = "0.1.0"
 thiserror = "1.0.20"
 pulldown-cmark = { version = "0.8.0", optional = true }
 log = "0.4"
+
+[dependencies.rustybuzz]
+version = "0.3.0"
+optional = true
 
 [dependencies.harfbuzz_rs]
 version = "1.1.2"

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -48,6 +48,10 @@ pub fn to_usize(x: u32) -> usize {
 pub(crate) struct DPU(pub(crate) f32);
 
 impl DPU {
+    #[cfg(feature = "rustybuzz")]
+    pub(crate) fn i32_to_px(self, x: i32) -> f32 {
+        x as f32 * self.0
+    }
     pub(crate) fn i16_to_px(self, x: i16) -> f32 {
         f32::from(x) * self.0
     }

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -7,7 +7,7 @@
 
 use super::TextDisplay;
 use crate::conv::{to_u32, to_usize};
-use crate::fonts::FontId;
+use crate::fonts::{fonts, FontId};
 use crate::format::FormattableText;
 use crate::{shaper, Action, Direction, Range};
 use unicode_bidi::{BidiInfo, Level, LTR_LEVEL, RTL_LEVEL};
@@ -72,7 +72,7 @@ impl TextDisplay {
                 text.as_str(),
                 run.range,
                 dpem,
-                run.font_id,
+                run.face_id,
                 breaks,
                 run.special,
                 run.level,
@@ -118,6 +118,10 @@ impl TextDisplay {
                 next_fmt = font_tokens.next();
             }
         }
+
+        let fonts = fonts();
+        // TODO: resolve face per character
+        let mut face_id = fonts.first_face_for(font_id);
 
         let bidi = bidi;
         let default_para_level = match dir {
@@ -179,7 +183,7 @@ impl TextDisplay {
                     text.as_str(),
                     range,
                     dpem,
-                    font_id,
+                    face_id,
                     breaks,
                     special,
                     level,
@@ -192,6 +196,7 @@ impl TextDisplay {
                         next_fmt = font_tokens.next();
                     }
                 }
+                face_id = fonts.first_face_for(font_id);
 
                 if hard_break {
                     let range = Range::from(line_start..self.runs.len());
@@ -235,7 +240,7 @@ impl TextDisplay {
             text.as_str(),
             range,
             dpem,
-            font_id,
+            face_id,
             breaks,
             special,
             level,
@@ -260,7 +265,7 @@ impl TextDisplay {
                 text.as_str(),
                 range,
                 dpem,
-                font_id,
+                face_id,
                 breaks,
                 RunSpecial::None,
                 level,

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -103,7 +103,7 @@ impl TextDisplay {
                         // re-ordering the line based on full line contents,
                         // then use a checkpoint reset if too long.
 
-                        let sf = fonts.get(run.font_id).scale_by_dpu(run.dpu);
+                        let sf = fonts.get_face(run.face_id).scale_by_dpu(run.dpu);
                         // TODO: custom tab sizes?
                         let tab_size = sf.h_advance(sf.glyph_id(' ')) * 8.0;
                         let stops = (caret / tab_size).floor() + 1.0;
@@ -229,7 +229,7 @@ impl LineAdder {
             last_run = part.run;
             let run = &runs[to_usize(last_run)];
 
-            let scale_font = fonts.get(run.font_id).scale_by_dpu(run.dpu);
+            let scale_font = fonts.get_face(run.face_id).scale_by_dpu(run.dpu);
             ascent = ascent.max(scale_font.ascent());
             descent = descent.min(scale_font.descent());
             line_gap = line_gap.max(scale_font.line_gap());

--- a/src/env.rs
+++ b/src/env.rs
@@ -93,7 +93,7 @@ impl Environment {
     /// To use "the standard font", use `Default::default()`.
     pub fn height(&self, font_id: FontId) -> f32 {
         let dpem = self.pt_size * self.dpp;
-        fonts().get(font_id).height(dpem)
+        fonts().get_first_face(font_id).height(dpem)
     }
 }
 

--- a/src/fonts/families.rs
+++ b/src/fonts/families.rs
@@ -22,7 +22,7 @@
 //!
 //! Font family ordering indicates usage preference.
 
-const DEFAULT_SERIF: [&'static str; 12] = [
+pub const DEFAULT_SERIF: [&'static str; 12] = [
     "serif",
     "Palatino Linotype",
     "Palatino",
@@ -37,7 +37,7 @@ const DEFAULT_SERIF: [&'static str; 12] = [
     "Liberation Serif",
 ];
 
-const DEFAULT_SANS_SERIF: [&'static str; 16] = [
+pub const DEFAULT_SANS_SERIF: [&'static str; 16] = [
     "sans-serif",
     "Tahoma",
     "Noto Sans",
@@ -56,7 +56,7 @@ const DEFAULT_SANS_SERIF: [&'static str; 16] = [
     "Lucida Sans Unicode",
 ];
 
-const DEFAULT_MONOSPACE: [&'static str; 18] = [
+pub const DEFAULT_MONOSPACE: [&'static str; 18] = [
     "monospace",
     "Consolas",
     "Droid Sans Mono",
@@ -77,7 +77,7 @@ const DEFAULT_MONOSPACE: [&'static str; 18] = [
     "Courier",
 ];
 
-const DEFAULT_CURSIVE: [&'static str; 5] = [
+pub const DEFAULT_CURSIVE: [&'static str; 5] = [
     "cursive",
     "Gabriola",
     "Segoe Script",
@@ -85,32 +85,10 @@ const DEFAULT_CURSIVE: [&'static str; 5] = [
     "Comic Sans MS",
 ];
 
-const DEFAULT_FANTASY: [&'static str; 5] = [
+pub const DEFAULT_FANTASY: [&'static str; 5] = [
     "fantasy",
     "Segoe Print",
     "Impact",
     "Apple Chancery",
     "Papyrus",
 ];
-
-/// Use this to set default font families after loading fonts
-pub fn set_defaults(db: &mut fontdb::Database) {
-    // fontdb does not set a default font for each category, so we should do that now.
-    macro_rules! set_family {
-        ($lt:tt, $FAMILY:ident, $set_fn:ident) => {
-            $lt: for name in $FAMILY.iter().cloned() {
-                for face in db.faces() {
-                    if name == face.family {
-                        db.$set_fn(name);
-                        break $lt;
-                    }
-                }
-            }
-        }
-    }
-    set_family!('a, DEFAULT_SERIF, set_serif_family);
-    set_family!('b, DEFAULT_SANS_SERIF, set_sans_serif_family);
-    set_family!('c, DEFAULT_MONOSPACE, set_monospace_family);
-    set_family!('d, DEFAULT_CURSIVE, set_cursive_family);
-    set_family!('e, DEFAULT_FANTASY, set_fantasy_family);
-}

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -154,6 +154,38 @@ impl FontLibrary {
         self.get_face(face_id)
     }
 
+    /// Resolve the face for a character
+    ///
+    /// This selects the first face containing this glyph from the font list.
+    pub fn face_for_char(&self, font_id: FontId, c: char) -> Option<FaceId> {
+        let faces = self.faces.read().unwrap();
+        let fonts = self.fonts.read().unwrap();
+        let list = fonts
+            .fonts
+            .iter()
+            .find(|item| item.0 == font_id)
+            .map(|item| &item.1)
+            .expect("invalid FontId");
+        for face_id in list.iter() {
+            let face = &faces.faces[face_id.get()];
+            // TODO: should we only return faces with shaping data, somehow?
+            if face.face.glyph_index(c).is_some() {
+                return Some(*face_id);
+            }
+        }
+        None
+    }
+
+    /// Resolve the face for a character
+    ///
+    /// This selects the first face containing this glyph from the font list,
+    /// otherwise choosing the first face.
+    #[inline]
+    pub fn face_for_char_or_first(&self, font_id: FontId, c: char) -> FaceId {
+        self.face_for_char(font_id, c)
+            .unwrap_or_else(|| self.first_face_for(font_id))
+    }
+
     /// Select the default font
     ///
     /// This *must* be called (at least once) before any other font-loading

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -28,6 +28,22 @@ enum FontError {
 ///
 /// Identifies a loaded font face within the [`FontLibrary`] by index.
 ///
+/// Internally this uses a numeric identifier, which is always less than
+/// [`FontLibrary::num_faces`], assuming that at least one font has been loaded.
+/// [`FontLibrary::face_data`] may be used to retrieve the matching font.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct FaceId(pub u32);
+impl FaceId {
+    /// Get as `usize`
+    pub fn get(self) -> usize {
+        to_usize(self.0)
+    }
+}
+
+/// Font face identifier
+///
+/// Identifies a font list within the [`FontLibrary`] by index.
+///
 /// This type may be default-constructed to use the default font (whichever is
 /// loaded to the [`FontLibrary`] first). If no font is loaded, attempting to
 /// access a font with a (default-constructed) `FontId` will cause a panic in
@@ -35,6 +51,7 @@ enum FontError {
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct FontId(pub u32);
 impl FontId {
+    /// Get as `usize`
     pub fn get(self) -> usize {
         to_usize(self.0)
     }
@@ -64,19 +81,32 @@ impl<'a> FaceStore<'a> {
 }
 
 #[derive(Default)]
-struct FontsData {
-    fonts: Vec<Box<FaceStore<'static>>>,
+struct FaceList {
+    faces: Vec<Box<FaceStore<'static>>>,
     // These are vec-maps. Why? Because length should be short.
-    sel_hash: Vec<(u64, FontId)>,
-    path_hash: Vec<(u64, FontId)>,
+    path_hash: Vec<(u64, FaceId)>,
 }
 
-impl FontsData {
-    fn push(&mut self, font: Box<FaceStore<'static>>, sel_hash: u64, path_hash: u64) -> FontId {
-        let id = FontId(to_u32(self.fonts.len()));
-        self.fonts.push(font);
-        self.sel_hash.push((sel_hash, id));
+impl FaceList {
+    fn push(&mut self, face: Box<FaceStore<'static>>, path_hash: u64) -> FaceId {
+        let id = FaceId(to_u32(self.faces.len()));
+        self.faces.push(face);
         self.path_hash.push((path_hash, id));
+        id
+    }
+}
+
+#[derive(Default)]
+struct FontList {
+    fonts: Vec<(FontId, Vec<FaceId>)>,
+    sel_hash: Vec<(u64, FontId)>,
+}
+
+impl FontList {
+    fn push(&mut self, list: Vec<FaceId>, sel_hash: u64) -> FontId {
+        let id = FontId(to_u32(self.fonts.len()));
+        self.fonts.push((id, list));
+        self.sel_hash.push((sel_hash, id));
         id
     }
 }
@@ -91,84 +121,61 @@ pub struct FontLibrary {
     // are never modified or removed (though the Vec is allowed to reallocate).
     // Note: using std::pin::Pin does not help since u8 impls Unpin.
     data: RwLock<HashMap<PathBuf, Box<[u8]>>>,
-    // Fonts defined over the above data (see safety note).
-    // Additional safety: fonts are boxed so that instances do not move
-    fonts: RwLock<FontsData>,
+    // Font faces defined over the above data (see safety note).
+    // Additional safety: `FaceStore` instances are boxed and so cannot move
+    faces: RwLock<FaceList>,
+    fonts: RwLock<FontList>,
 }
 
-// public API
+/// Font management
 impl FontLibrary {
-    /// Get a font from its identifier
+    /// Get the first face for a font
     ///
-    /// Panics if `id` is not valid (required: `id.get() < self.num_fonts()`).
-    pub fn get(&self, id: FontId) -> FaceRef {
-        let fonts = self.fonts.read().unwrap();
-        assert!(
-            id.get() < fonts.fonts.len(),
-            "FontLibrary: invalid {:?}!",
-            id
-        );
-        let face: &Face<'static> = &fonts.fonts[id.get()].face;
-        // Safety: elements of self.fonts are never dropped or modified
-        let face = unsafe { extend_lifetime(face) };
-        FaceRef(face)
-    }
-
-    /// Get a HarfBuzz font face
-    #[cfg(feature = "harfbuzz_rs")]
-    pub(crate) fn get_harfbuzz(
-        &self,
-        id: FontId,
-    ) -> harfbuzz_rs::Owned<harfbuzz_rs::Font<'static>> {
-        let fonts = self.fonts.read().unwrap();
-        assert!(
-            id.get() < fonts.fonts.len(),
-            "FontLibrary: invalid {:?}!",
-            id
-        );
-        harfbuzz_rs::Font::new(fonts.fonts[id.get()].harfbuzz.clone())
-    }
-
-    /// Get the number of loaded font faces
+    /// Assumes that `font_id` is valid; if not the method will panic.
     ///
-    /// [`FontId`] values are indices assigned consecutively and are permanent.
-    /// For any `x < self.num_fonts()`, `FontId(x)` is a valid font identifier.
-    ///
-    /// Font faces may be loaded on demand (by [`crate::Text::prepare`] but are
-    /// never unloaded or adjusted, hence this value may increase but not decrease.
-    pub fn num_fonts(&self) -> usize {
+    /// Each font identifier has at least one font face. This resolves the first
+    /// (default) one.
+    pub fn first_face_for(&self, font_id: FontId) -> FaceId {
         let fonts = self.fonts.read().unwrap();
-        fonts.fonts.len()
-    }
-
-    /// Access loaded font data
-    pub fn font_data<'a>(&'a self) -> FontData<'a> {
-        FontData {
-            fonts: self.fonts.read().unwrap(),
-            data: self.data.read().unwrap(),
+        for (id, list) in &fonts.fonts {
+            if *id == font_id {
+                return *list.first().unwrap();
+            }
         }
+        panic!("FontLibrary::first_face_for: invalid font_id")
     }
 
-    /// Load a default font
+    /// Get the first face for a font
     ///
-    /// This *must* be called before any other font-loading method.
-    ///
-    /// This should be at least once before attempting to query any font-derived
-    /// properties (such as text dimensions).
+    /// This is a wrapper around [`FontLibrary::first_face_for`] and [`FontLibrary::get_face`].
     #[inline]
-    pub fn load_default(&self) -> Result<FontId, Box<dyn std::error::Error>> {
-        let id = self.load_font(&FontSelector::default())?;
+    pub fn get_first_face(&self, font_id: FontId) -> FaceRef {
+        let face_id = self.first_face_for(font_id);
+        self.get_face(face_id)
+    }
+
+    /// Select the default font
+    ///
+    /// This *must* be called (at least once) before any other font-loading
+    /// method, and before querying any font-derived properties (such as text
+    /// dimensions).
+    #[inline]
+    pub fn select_default(&self) -> Result<FontId, Box<dyn std::error::Error>> {
+        let id = self.select_font(&FontSelector::default())?;
         if id != FontId::default() {
             return Err(Box::new(FontError::NotDefault));
         }
         Ok(id)
     }
 
-    /// Load a font
+    /// Select a font
     ///
-    /// This method uses two levels of caching to resolve existing
-    /// fonts, thus is suitable for repeated usage.
-    pub fn load_font(&self, selector: &FontSelector) -> Result<FontId, Box<dyn std::error::Error>> {
+    /// This method uses internal caching to enable fast look-ups of existing
+    /// (loaded) fonts. Resolving new fonts may be slower.
+    pub fn select_font(
+        &self,
+        selector: &FontSelector,
+    ) -> Result<FontId, Box<dyn std::error::Error>> {
         let sel_hash = selector.hash();
         let fonts = self.fonts.read().unwrap();
         for (h, id) in &fonts.sel_hash {
@@ -179,9 +186,65 @@ impl FontLibrary {
         drop(fonts);
 
         let (source, index) = selector.select(&self.db).ok_or(FontError::NotFound)?;
-        match source {
+        let face = match source {
             fontdb::Source::Binary(_) => unimplemented!(),
-            fontdb::Source::File(path) => self.load_path(path, index, sel_hash),
+            fontdb::Source::File(path) => self.load_path(path, index),
+        }?;
+
+        Ok(self.fonts.write().unwrap().push(vec![face], sel_hash))
+    }
+}
+
+/// Face management
+impl FontLibrary {
+    /// Get a font face from its identifier
+    ///
+    /// Panics if `id` is not valid (required: `id.get() < self.num_faces()`).
+    pub fn get_face(&self, id: FaceId) -> FaceRef {
+        let faces = self.faces.read().unwrap();
+        assert!(
+            id.get() < faces.faces.len(),
+            "FontLibrary: invalid {:?}!",
+            id
+        );
+        let face: &Face<'static> = &faces.faces[id.get()].face;
+        // Safety: elements of self.faces are never dropped or modified
+        let face = unsafe { extend_lifetime(face) };
+        FaceRef(face)
+    }
+
+    /// Get a HarfBuzz font face
+    #[cfg(feature = "harfbuzz_rs")]
+    pub(crate) fn get_harfbuzz(
+        &self,
+        id: FaceId,
+    ) -> harfbuzz_rs::Owned<harfbuzz_rs::Font<'static>> {
+        let faces = self.faces.read().unwrap();
+        assert!(
+            id.get() < faces.faces.len(),
+            "FontLibrary: invalid {:?}!",
+            id
+        );
+        harfbuzz_rs::Font::new(faces.faces[id.get()].harfbuzz.clone())
+    }
+
+    /// Get the number of loaded font faces
+    ///
+    /// [`FaceId`] values are indices assigned consecutively and are permanent.
+    /// For any `x < self.num_faces()`, `FaceId(x)` is a valid font face identifier.
+    ///
+    /// Font faces may be loaded on demand (by [`crate::Text::prepare`] but are
+    /// never unloaded or adjusted, hence this value may increase but not decrease.
+    pub fn num_faces(&self) -> usize {
+        let faces = self.faces.read().unwrap();
+        faces.faces.len()
+    }
+
+    /// Access loaded font face data
+    pub fn face_data<'a>(&'a self) -> FaceData<'a> {
+        FaceData {
+            faces: self.faces.read().unwrap(),
+            data: self.data.read().unwrap(),
         }
     }
 
@@ -192,25 +255,17 @@ impl FontLibrary {
     ///
     /// The `index` is used to select fonts from a font-collection. If the font
     /// is not a collection, use `0`.
-    ///
-    /// `sel_hash` is the hash of the [`FontSelector`] used; if this is not
-    /// used, pass 0.
-    pub fn load_path(
-        &self,
-        path: &Path,
-        index: u32,
-        sel_hash: u64,
-    ) -> Result<FontId, Box<dyn std::error::Error>> {
+    pub fn load_path(&self, path: &Path, index: u32) -> Result<FaceId, Box<dyn std::error::Error>> {
         let path_hash = self.hash_path(path, index);
 
         // 1st lock: early exit if we already have this font
-        let fonts = self.fonts.read().unwrap();
-        for (h, id) in &fonts.path_hash {
+        let faces = self.faces.read().unwrap();
+        for (h, id) in &faces.path_hash {
             if *h == path_hash {
                 return Ok(*id);
             }
         }
-        drop(fonts);
+        drop(faces);
 
         // 2nd lock: load and store file data / get reference
         let mut data = self.data.write().unwrap();
@@ -228,8 +283,8 @@ impl FontLibrary {
 
         // 3rd lock: insert into font list
         let store = FaceStore::new(path.to_owned(), slice, index)?;
-        let mut fonts = self.fonts.write().unwrap();
-        let id = fonts.push(Box::new(store), sel_hash, path_hash);
+        let mut faces = self.faces.write().unwrap();
+        let id = faces.push(Box::new(store), path_hash);
 
         log::debug!("Loaded: {:?} = {},{}", id, path.display(), index);
         Ok(id)
@@ -248,31 +303,31 @@ impl FontLibrary {
 
 /// Provides access to font data
 ///
-/// Each valid [`FontId`] is an index to a loaded font face. Since fonts are
-/// never unloaded or replaced, [`FontId::get`] is a valid index into these
-/// arrays for any valid [`FontId`].
-pub struct FontData<'a> {
-    fonts: RwLockReadGuard<'a, FontsData>,
+/// Each valid [`FaceId`] is an index to a loaded font face. Since faces are
+/// never unloaded or replaced, [`FaceId::get`] is a valid index into these
+/// arrays for any valid [`FaceId`].
+pub struct FaceData<'a> {
+    faces: RwLockReadGuard<'a, FaceList>,
     data: RwLockReadGuard<'a, HashMap<PathBuf, Box<[u8]>>>,
 }
-impl<'a> FontData<'a> {
-    /// Number of available fonts
+impl<'a> FaceData<'a> {
+    /// Number of available font faces
     pub fn len(&self) -> usize {
-        self.fonts.fonts.len()
+        self.faces.faces.len()
     }
 
     /// Access font path and face index
     ///
-    /// Note: use [`FontData::get_data`] to access the font file data, already
+    /// Note: use [`FaceData::get_data`] to access the font file data, already
     /// loaded into memory.
     pub fn get_path(&self, index: usize) -> (&Path, u32) {
-        let f = &self.fonts.fonts[index];
+        let f = &self.faces.faces[index];
         (&f.path, f.index)
     }
 
     /// Access font data and face index
     pub fn get_data(&self, index: usize) -> (&'static [u8], u32) {
-        let f = &self.fonts.fonts[index];
+        let f = &self.faces.faces[index];
         let data = self.data.get(&f.path).unwrap();
         // Safety: data is in FontLibrary::data and will not be dropped or modified
         let data = unsafe { extend_lifetime(data) };
@@ -295,6 +350,7 @@ impl FontLibrary {
         FontLibrary {
             db,
             data: Default::default(),
+            faces: Default::default(),
             fonts: Default::default(),
         }
     }

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -208,7 +208,7 @@ impl FontLibrary {
         &self,
         selector: &FontSelector,
     ) -> Result<FontId, Box<dyn std::error::Error>> {
-        let sel_hash = selector.hash();
+        let sel_hash = calculate_hash(&selector);
         let fonts = self.fonts.read().unwrap();
         for (h, id) in &fonts.sel_hash {
             if *h == sel_hash {
@@ -400,4 +400,13 @@ lazy_static::lazy_static! {
 /// Access the [`FontLibrary`] singleton
 pub fn fonts() -> &'static FontLibrary {
     &*LIBRARY
+}
+
+fn calculate_hash<T: std::hash::Hash>(t: &T) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hasher;
+
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    s.finish()
 }

--- a/src/fonts/mod.rs
+++ b/src/fonts/mod.rs
@@ -10,13 +10,13 @@
 //!
 //! ### FontId and the default font
 //!
-//! The [`FontId`] type is a numeric identifier for loaded fonts. It may be
+//! The [`FontId`] type is a numeric identifier for a selected font. It may be
 //! default-constructed to access the *default* font, with number 0.
 //!
 //! To make this work, the user of this library *must* load the default font
 //! before all other fonts and before any operation requiring font metrics:
 //! ```
-//! if let Err(e) = kas_text::fonts::fonts().load_default() {
+//! if let Err(e) = kas_text::fonts::fonts().select_default() {
 //!     panic!("Error loading font: {}", e);
 //! }
 //! // from now on, kas_text::fonts::FontId::default() identifies the default font
@@ -27,6 +27,13 @@
 //! If doing this, `load_default` must not be called at all.
 //! It is harmless to attempt to load any font multiple times, whether with
 //! `load_default` or another method.)
+//!
+//! ### FaceId vs FontId
+//!
+//! Why do both [`FaceId`] and [`FontId`] exist? Font fallbacks. A [`FontId`]
+//! identifies a list of font faces; when selecting glyphs the first face which
+//! includes that glyph is selected. Thus, when iterating over glyphs for
+//! rendering purposes, each has an associated [`FaceId`].
 //!
 //! ### Font sizes
 //!
@@ -71,7 +78,7 @@ mod selector;
 
 pub use face::FaceRef;
 pub(crate) use face::ScaledFaceRef;
-pub use library::{fonts, FontData, FontId, FontLibrary};
+pub use library::{fonts, FaceData, FaceId, FontId, FontLibrary};
 pub use selector::*;
 
 impl From<GlyphId> for ttf_parser::GlyphId {

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -15,35 +15,12 @@ pub use fontdb::{Family, Stretch, Style, Weight};
 ///
 /// This tool selects a font according to the given criteria from available
 /// system fonts. Selection criteria are based on CSS.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub struct FontSelector<'a> {
     names: Vec<Family<'a>>,
     weight: Weight,
     stretch: Stretch,
     style: Style,
-}
-
-impl<'a> PartialEq for FontSelector<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        // This really should be derived...
-        fn family_eq((a, b): (&Family, &Family)) -> bool {
-            match (a, b) {
-                (Family::Name(a), Family::Name(b)) => a == b,
-                (Family::Serif, Family::Serif) => true,
-                (Family::SansSerif, Family::SansSerif) => true,
-                (Family::Cursive, Family::Cursive) => true,
-                (Family::Fantasy, Family::Fantasy) => true,
-                (Family::Monospace, Family::Monospace) => true,
-                _ => false,
-            }
-        }
-
-        self.names.len() == other.names.len()
-            && self.names.iter().zip(other.names.iter()).all(family_eq)
-            && self.weight == other.weight
-            && self.stretch == other.stretch
-            && self.style == other.style
-    }
 }
 
 impl<'a> FontSelector<'a> {
@@ -96,36 +73,6 @@ impl<'a> FontSelector<'a> {
     #[inline]
     pub fn set_stretch(&mut self, stretch: Stretch) {
         self.stretch = stretch;
-    }
-
-    /// Hash self
-    ///
-    /// This struct does not implement `Hash` since it doesn't precisely match
-    /// the expected semantics: values may compare equal despite having
-    /// different hashes. For our purposes this is acceptable.
-    pub fn hash(&self) -> u64 {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        let mut hasher = DefaultHasher::new();
-        self.names.len().hash(&mut hasher);
-        for name in &self.names {
-            match name {
-                Family::Name(name) => {
-                    0u16.hash(&mut hasher);
-                    name.hash(&mut hasher);
-                }
-                Family::Serif => 1u16.hash(&mut hasher),
-                Family::SansSerif => 2u16.hash(&mut hasher),
-                Family::Cursive => 3u16.hash(&mut hasher),
-                Family::Fantasy => 4u16.hash(&mut hasher),
-                Family::Monospace => 5u16.hash(&mut hasher),
-            }
-        }
-        self.weight.0.hash(&mut hasher);
-        self.stretch.to_number().hash(&mut hasher);
-        (self.style as u16).hash(&mut hasher);
-        hasher.finish()
     }
 
     /// Resolve font faces for each matching font

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -7,6 +7,8 @@
 //!
 //! Many items are copied from font-kit to avoid any public dependency.
 
+use super::families;
+use fontdb::{Database, FaceInfo, Source};
 pub use fontdb::{Family, Stretch, Style, Weight};
 
 /// A font face selection tool
@@ -126,21 +128,210 @@ impl<'a> FontSelector<'a> {
         hasher.finish()
     }
 
-    /// Resolve a path and collection index from the given criteria
-    pub(crate) fn select<'b>(&self, db: &'b fontdb::Database) -> Option<(&'b fontdb::Source, u32)> {
-        let mut families = &[fontdb::Family::SansSerif][..];
+    /// Resolve font faces for each matching font
+    ///
+    /// This implements CSS selection logic as defined by
+    /// [https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#font-style-matching](),
+    /// steps 1-4. The result is a list of matching font faces which may later
+    /// be matched against characters for character-level fallback (step 5).
+    ///
+    /// All font faces matching steps 1-4 will be returned through the `add_face` closure.
+    pub(crate) fn select<'b, F>(
+        &'b self,
+        db: &'b Database,
+        mut add_face: F,
+    ) -> Result<(), Box<dyn std::error::Error>>
+    where
+        F: FnMut(&'b Source, u32) -> Result<(), Box<dyn std::error::Error>>,
+    {
+        let faces: Vec<(String, &FaceInfo)> = db
+            .faces()
+            .iter()
+            .map(|face| (face.family.to_uppercase(), face))
+            .collect();
+
+        // We allow an empty family list to resolve to SansSerif.
+        let mut families = &[Family::SansSerif][..];
         if self.names.len() > 0 {
             families = &self.names[..];
         }
 
-        let query = fontdb::Query {
-            families,
-            weight: self.weight,
-            stretch: self.stretch,
-            style: self.style,
+        let mut candidates = Vec::new();
+        for family in families {
+            // Resolve implied family name(s).
+            // This is vaguely step 2, but allows generic names to resolve to multiple targets.
+            let mut name_arr = [""];
+            let names: &[&str] = match family {
+                Family::Name(name) => {
+                    name_arr[0] = name;
+                    &name_arr
+                }
+                Family::Serif => &families::DEFAULT_SERIF,
+                Family::SansSerif => &families::DEFAULT_SANS_SERIF,
+                Family::Cursive => &families::DEFAULT_CURSIVE,
+                Family::Fantasy => &families::DEFAULT_FANTASY,
+                Family::Monospace => &families::DEFAULT_MONOSPACE,
+            };
+
+            // Step 3: find any matching font faces, case-insensitively, including localised
+            // variants (starts_with may be overly permissive here).
+            for name in names.iter() {
+                for (upper_name, face) in faces.iter() {
+                    // TODO: exact match only or starting-with?
+                    // if upper_name.starts_with(&name.to_uppercase()) {
+                    if *upper_name == name.to_uppercase() {
+                        candidates.push(*face);
+                    }
+                }
+
+                // Step 4: if any match from a family, narrow to a single face.
+                if !candidates.is_empty() {
+                    if let Some(index) = self.find_best_match(&candidates) {
+                        let candidate = candidates[index];
+                        add_face(&candidate.source, candidate.index)?;
+                    }
+                    candidates.clear();
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    // https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#font-style-matching
+    // Based on https://github.com/RazrFalcon/fontdb, itself based on https://github.com/servo/font-kit
+    #[inline(never)]
+    fn find_best_match(&self, candidates: &[&FaceInfo]) -> Option<usize> {
+        debug_assert!(!candidates.is_empty());
+
+        // Step 4.
+        let mut matching_set: Vec<usize> = (0..candidates.len()).collect();
+
+        // Step 4a (`font-stretch`).
+        let matches = matching_set
+            .iter()
+            .any(|&index| candidates[index].stretch == self.stretch);
+        let matching_stretch = if matches {
+            // Exact match.
+            self.stretch
+        } else if self.stretch <= Stretch::Normal {
+            // Closest stretch, first checking narrower values and then wider values.
+            let stretch = matching_set
+                .iter()
+                .filter(|&&index| candidates[index].stretch < self.stretch)
+                .min_by_key(|&&index| {
+                    self.stretch.to_number() - candidates[index].stretch.to_number()
+                });
+
+            match stretch {
+                Some(&matching_index) => candidates[matching_index].stretch,
+                None => {
+                    let matching_index = *matching_set.iter().min_by_key(|&&index| {
+                        candidates[index].stretch.to_number() - self.stretch.to_number()
+                    })?;
+
+                    candidates[matching_index].stretch
+                }
+            }
+        } else {
+            // Closest stretch, first checking wider values and then narrower values.
+            let stretch = matching_set
+                .iter()
+                .filter(|&&index| candidates[index].stretch > self.stretch)
+                .min_by_key(|&&index| {
+                    candidates[index].stretch.to_number() - self.stretch.to_number()
+                });
+
+            match stretch {
+                Some(&matching_index) => candidates[matching_index].stretch,
+                None => {
+                    let matching_index = *matching_set.iter().min_by_key(|&&index| {
+                        self.stretch.to_number() - candidates[index].stretch.to_number()
+                    })?;
+
+                    candidates[matching_index].stretch
+                }
+            }
         };
-        db.query(&query)
-            .and_then(|id| db.face(id))
-            .map(|face| (&*face.source, face.index))
+        matching_set.retain(|&index| candidates[index].stretch == matching_stretch);
+
+        // Step 4b (`font-style`).
+        let style_preference = match self.style {
+            Style::Italic => [Style::Italic, Style::Oblique, Style::Normal],
+            Style::Oblique => [Style::Oblique, Style::Italic, Style::Normal],
+            Style::Normal => [Style::Normal, Style::Oblique, Style::Italic],
+        };
+        let matching_style = *style_preference
+            .iter()
+            .filter(|&query_style| {
+                matching_set
+                    .iter()
+                    .any(|&index| candidates[index].style == *query_style)
+            })
+            .next()?;
+
+        matching_set.retain(|&index| candidates[index].style == matching_style);
+
+        // Step 4c (`font-weight`).
+        //
+        // The spec doesn't say what to do if the weight is between 400 and 500 exclusive, so we
+        // just use 450 as the cutoff.
+        let weight = self.weight.0;
+        let matches = weight >= 400
+            && weight < 450
+            && matching_set
+                .iter()
+                .any(|&index| candidates[index].weight.0 == 500);
+
+        let matching_weight = if matches {
+            // Check 500 first.
+            Weight::MEDIUM
+        } else if weight >= 450
+            && weight <= 500
+            && matching_set
+                .iter()
+                .any(|&index| candidates[index].weight.0 == 400)
+        {
+            // Check 400 first.
+            Weight::NORMAL
+        } else if weight <= 500 {
+            // Closest weight, first checking thinner values and then fatter ones.
+            let idx = matching_set
+                .iter()
+                .filter(|&&index| candidates[index].weight.0 <= weight)
+                .min_by_key(|&&index| weight - candidates[index].weight.0);
+
+            match idx {
+                Some(&matching_index) => candidates[matching_index].weight,
+                None => {
+                    let matching_index = *matching_set
+                        .iter()
+                        .min_by_key(|&&index| candidates[index].weight.0 - weight)?;
+                    candidates[matching_index].weight
+                }
+            }
+        } else {
+            // Closest weight, first checking fatter values and then thinner ones.
+            let idx = matching_set
+                .iter()
+                .filter(|&&index| candidates[index].weight.0 >= weight)
+                .min_by_key(|&&index| candidates[index].weight.0 - weight);
+
+            match idx {
+                Some(&matching_index) => candidates[matching_index].weight,
+                None => {
+                    let matching_index = *matching_set
+                        .iter()
+                        .min_by_key(|&&index| weight - candidates[index].weight.0)?;
+                    candidates[matching_index].weight
+                }
+            }
+        };
+        matching_set.retain(|&index| candidates[index].weight == matching_weight);
+
+        // Ignore step 4d (`font-size`).
+
+        // Return the result.
+        matching_set.into_iter().next()
     }
 }

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -120,12 +120,9 @@ impl<'a> FontSelector<'a> {
                 Family::Monospace => &families::DEFAULT_MONOSPACE,
             };
 
-            // Step 3: find any matching font faces, case-insensitively, including localised
-            // variants (starts_with may be overly permissive here).
+            // Step 3: find any matching font faces, case-insensitively
             for name in names.iter() {
                 for (upper_name, face) in faces.iter() {
-                    // TODO: exact match only or starting-with?
-                    // if upper_name.starts_with(&name.to_uppercase()) {
                     if *upper_name == name.to_uppercase() {
                         candidates.push(*face);
                     }

--- a/src/format/markdown.rs
+++ b/src/format/markdown.rs
@@ -65,7 +65,7 @@ impl<'a> Iterator for FontTokenIter<'a> {
         if self.index < self.fmt.len() {
             let fmt = &self.fmt[self.index];
             if self.font_sel != fmt.sel {
-                self.font_id = self.fonts.load_font(&fmt.sel).unwrap();
+                self.font_id = self.fonts.select_font(&fmt.sel).unwrap();
                 self.font_sel.assign(&fmt.sel);
             }
             self.index += 1;

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -252,7 +252,10 @@ pub(crate) fn shape(
         #[cfg(feature = "harfbuzz_rs")]
         let r = shape_harfbuzz(text, range, dpem, face_id, level, &mut breaks);
 
-        #[cfg(not(feature = "harfbuzz_rs"))]
+        #[cfg(all(not(feature = "harfbuzz_rs"), feature = "rustybuzz"))]
+        let r = shape_rustybuzz(text, range, dpem, face_id, level, &mut breaks);
+
+        #[cfg(all(not(feature = "harfbuzz_rs"), not(feature = "rustybuzz")))]
         let r = shape_simple(sf, text, range, level, &mut breaks);
 
         glyphs = r.0;
@@ -390,8 +393,93 @@ fn shape_harfbuzz(
     (glyphs, no_space_end, caret)
 }
 
+// Use Rustybuzz lib
+#[cfg(all(not(feature = "harfbuzz_rs"), feature = "rustybuzz"))]
+fn shape_rustybuzz(
+    text: &str,
+    range: Range,
+    dpem: f32,
+    face_id: FaceId,
+    level: Level,
+    breaks: &mut [GlyphBreak],
+) -> (Vec<Glyph>, f32, f32) {
+    let dpem = dpem;
+    let fonts = fonts();
+    let dpu = fonts.get_face(face_id).dpu(dpem);
+    let face = fonts.get_rustybuzz(face_id);
+
+    // ppem affects hinting but does not scale layout, so this has little effect:
+    // face.set_pixels_per_em(Some((dpem as u16, dpem as u16)));
+
+    let slice = &text[range];
+    let idx_offset = range.start;
+    let rtl = level.is_rtl();
+
+    // TODO: cache the buffer for reuse later?
+    let mut buffer = rustybuzz::UnicodeBuffer::new();
+    buffer.set_direction(match rtl {
+        false => rustybuzz::Direction::LeftToRight,
+        true => rustybuzz::Direction::RightToLeft,
+    });
+    buffer.push_str(slice);
+    let features = [];
+
+    let output = rustybuzz::shape(&face, &features, buffer);
+
+    let mut caret = 0.0;
+    let mut no_space_end = caret;
+    let mut break_i = 0;
+
+    let mut glyphs = Vec::with_capacity(output.len());
+
+    for (info, pos) in output
+        .glyph_infos()
+        .iter()
+        .zip(output.glyph_positions().iter())
+    {
+        let index = idx_offset + info.cluster;
+        assert!(info.codepoint <= u16::MAX as u32, "failed to map glyph id");
+        let id = GlyphId(info.codepoint as u16);
+
+        if breaks
+            .get(break_i)
+            .map(|b| b.index == index)
+            .unwrap_or(false)
+        {
+            breaks[break_i].pos = to_u32(glyphs.len());
+            breaks[break_i].no_space_end = no_space_end;
+            break_i += 1;
+        }
+
+        let position = Vec2(
+            caret + dpu.i32_to_px(pos.x_offset),
+            dpu.i32_to_px(pos.y_offset),
+        );
+        glyphs.push(Glyph {
+            index,
+            id,
+            position,
+        });
+
+        // IIRC this is only applicable to vertical text, which we don't
+        // currently support:
+        debug_assert_eq!(pos.y_advance, 0);
+        caret += dpu.i32_to_px(pos.x_advance);
+        if text[to_usize(index)..]
+            .chars()
+            .next()
+            .map(|c| !c.is_whitespace())
+            .unwrap()
+        {
+            no_space_end = caret;
+        }
+    }
+
+    (glyphs, no_space_end, caret)
+}
+
 // Simple implementation (kerning but no shaping)
-#[cfg(not(feature = "harfbuzz_rs"))]
+#[cfg(all(not(feature = "harfbuzz_rs"), not(feature = "rustybuzz")))]
 fn shape_simple(
     sf: crate::fonts::ScaledFaceRef,
     text: &str,

--- a/src/text.rs
+++ b/src/text.rs
@@ -8,7 +8,7 @@
 use std::convert::{AsMut, AsRef};
 
 use crate::display::{Effect, MarkerPosIter, TextDisplay};
-use crate::fonts::FontId;
+use crate::fonts::FaceId;
 use crate::format::{EditableText, FormattableText};
 use crate::{Action, Glyph, Vec2};
 use crate::{EnvFlags, Environment, UpdateEnv};
@@ -342,7 +342,7 @@ pub trait TextApiExt: TextApi {
     /// Yield a sequence of positioned glyphs
     ///
     /// Wraps [`TextDisplay::glyphs`].
-    fn glyphs<F: FnMut(FontId, f32, f32, Glyph)>(&self, f: F) {
+    fn glyphs<F: FnMut(FaceId, f32, f32, Glyph)>(&self, f: F) {
         self.display().glyphs(f)
     }
 
@@ -352,7 +352,7 @@ pub trait TextApiExt: TextApi {
     fn glyphs_with_effects<X, F, G>(&self, effects: &[Effect<X>], default_aux: X, f: F, g: G)
     where
         X: Copy,
-        F: FnMut(FontId, f32, f32, Glyph, usize, X),
+        F: FnMut(FaceId, f32, f32, Glyph, usize, X),
         G: FnMut(f32, f32, f32, f32, usize, X),
     {
         self.display()


### PR DESCRIPTION
This (roughly) implements font fallbacks.

But: on my system it resolves "Noto Sans" as the default font, however does not resolve international variants: my system includes "Noto Sans CJK HK", "Noto Sans CJK JP", "Noto Sans Sinhala", ...

@RazrFalcon may I ask, is there some way of resolving these variants from the base family name, "Noto Sans"? I cannot simply use `starts_with` since that would include "Noto Sans Black", "Noto Sans Mono" etc, thus I don't see a way from the information available in `fontdb` (attached). Or is it expected that the font-config list all variants of "Noto Sans"?

CSS font style matching step 4 must happen once per font (e.g. "Noto Sans CJK HK"), so e.g. "Noto Sans Black" must be excluded.

Also @RazrFalcon do you see some of this logic moving to fontdb? `find_best_match` is copied from there and something like `FontSelector::select` could be added as something like `Database::query_multiple`. The `set_serif_family` etc. methods are not useful here since "serif" may resolve to multiple fonts.