### PR TITLE
Font selection via aliases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ markdown = ["pulldown-cmark"]
 # Use Generic Associated Types (experimental)
 gat = []
 
+# Also:
+# serde: enable (de)serialization for a few types
+
 [dependencies]
 bitflags = "1.2.1"
 fontdb = "0.5.4"
@@ -36,6 +39,7 @@ unicode-bidi-mirroring = "0.1.0"
 thiserror = "1.0.20"
 pulldown-cmark = { version = "0.8.0", optional = true }
 log = "0.4"
+serde = { version = "1.0.123", features = ["derive"], optional = true }
 
 [dependencies.rustybuzz]
 version = "0.3.0"

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -48,7 +48,7 @@ pub fn to_usize(x: u32) -> usize {
 pub(crate) struct DPU(pub(crate) f32);
 
 impl DPU {
-    #[cfg(feature = "rustybuzz")]
+    #[cfg(all(not(feature = "harfbuzz_rs"), feature = "rustybuzz"))]
     pub(crate) fn i32_to_px(self, x: i32) -> f32 {
         x as f32 * self.0
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,6 +9,7 @@ use crate::conv::{to_u32, to_usize};
 
 /// 2D vector (position/size/offset) over `f32`
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vec2(pub f32, pub f32);
 
 impl Vec2 {
@@ -84,6 +85,7 @@ impl From<Vec2> for (f32, f32) {
 /// and the library is too complex to be useful on 16-bit CPUs, so using `u32`
 /// makes more sense than `usize`.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Range {
     pub start: u32,
     pub end: u32,

--- a/src/display.rs
+++ b/src/display.rs
@@ -133,7 +133,7 @@ impl TextDisplay {
 
         if action >= Action::All {
             let bidi = env.flags.contains(EnvFlags::BIDI);
-            self.prepare_runs(text, bidi, env.dir, env.dpp, env.pt_size);
+            self.prepare_runs(text, bidi, env.dir, env.font_id, env.dpp, env.pt_size);
         } else if action == Action::Resize {
             // Note: this is only needed if we didn't just call prepare_runs()
             self.resize_runs(text, env.dpp, env.pt_size);

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -12,6 +12,7 @@ use crate::{Glyph, Vec2};
 
 /// Effect formatting marker
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Effect<X> {
     /// Index in text at which formatting becomes active
     ///
@@ -38,6 +39,7 @@ impl<X> Effect<X> {
 bitflags::bitflags! {
     /// Text effects
     #[derive(Default)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct EffectFlags: u32 {
         /// Glyph is underlined
         const UNDERLINE = 1 << 0;

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -171,7 +171,7 @@ impl TextDisplay {
                 .map(|fmt| to_usize(fmt.start) == pos)
                 .unwrap_or(false);
 
-            let face_id = fonts.face_for_char_or_first(font_id, c);
+            let mut face_id = fonts.face_for_char_or_first(font_id, c);
             let font_break = pos > 0 && face_id != last_face_id;
 
             if hard_break || control_break || bidi_break || fmt_break || font_break {
@@ -197,6 +197,7 @@ impl TextDisplay {
                         dpem = fmt.dpem;
                         next_fmt = font_tokens.next();
                     }
+                    face_id = fonts.face_for_char_or_first(font_id, c);
                 }
 
                 if hard_break {

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -93,6 +93,7 @@ impl TextDisplay {
         text: &F,
         bidi: bool,
         dir: Direction,
+        mut font_id: FontId,
         dpp: f32,
         pt_size: f32,
     ) {
@@ -106,7 +107,6 @@ impl TextDisplay {
         self.line_runs.clear();
         self.action = Action::Wrap;
 
-        let mut font_id = FontId::default();
         let mut dpem = dpp * pt_size;
 
         let mut font_tokens = text.font_tokens(dpp, pt_size);

--- a/src/env.rs
+++ b/src/env.rs
@@ -199,6 +199,7 @@ bitflags::bitflags! {
     /// Environment flags
     ///
     /// By default, all flags are enabled
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct EnvFlags: u8 {
         /// Enable bidirectional text support
         const BIDI = 1 << 0;
@@ -217,6 +218,7 @@ impl Default for EnvFlags {
 ///
 /// Note that alignment information is often passed as a `(horiz, vert)` pair.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Align {
     /// Default alignment
     ///
@@ -245,6 +247,7 @@ impl Default for Align {
 ///
 /// This can be used to force the text direction.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Direction {
     /// Auto-detect (default)
     Auto,

--- a/src/env.rs
+++ b/src/env.rs
@@ -42,6 +42,11 @@ pub struct Environment {
     /// If `bidi == false` this directly sets the line direction, unless
     /// `dir == Auto`, in which case direction is auto-detected.
     pub dir: Direction,
+    /// Default font
+    ///
+    /// This font is used unless a formatting token (see [`crate::format`])
+    /// is used.
+    pub font_id: FontId,
     /// Pixels-per-point
     ///
     /// This is a scaling factor used to convert font sizes (in points) to a
@@ -77,6 +82,7 @@ impl Default for Environment {
         Environment {
             flags: Default::default(),
             dir: Direction::default(),
+            font_id: Default::default(),
             dpp: 96.0 / 72.0,
             pt_size: 11.0,
             bounds: Vec2::INFINITY,
@@ -256,5 +262,5 @@ impl Default for Direction {
 
 #[test]
 fn size() {
-    assert_eq!(std::mem::size_of::<Environment>(), 20);
+    assert_eq!(std::mem::size_of::<Environment>(), 24);
 }

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -5,7 +5,7 @@
 
 //! Font library
 
-use super::{selector, FaceRef, FontSelector};
+use super::{selector::Database, FaceRef, FontSelector};
 use crate::conv::{to_u32, to_usize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -122,7 +122,7 @@ impl FontList {
 /// This is the type of the global singleton accessible via the [`fonts`]
 /// function. Thread-safety is handled via internal locks.
 pub struct FontLibrary {
-    db: selector::Database,
+    db: RwLock<Database>,
     // Font files loaded into memory. Safety: we assume that existing entries
     // are never modified or removed (though the Vec is allowed to reallocate).
     // Note: using std::pin::Pin does not help since u8 impls Unpin.
@@ -135,6 +135,18 @@ pub struct FontLibrary {
 
 /// Font management
 impl FontLibrary {
+    /// Get mutable access to the font database
+    ///
+    /// This can be used to adjust font selection. Note that any changes only
+    /// affect *new* font selections, thus it is recommended only to adjust the
+    /// database before *any* fonts have been selected. No existing [`FaceId`]
+    /// or [`FontId`] will be affected by this; additionally any
+    /// [`FontSelector`] which has already been selected will continue to
+    /// resolve the existing [`FontId`] via the cache.
+    pub fn update_db<F: FnOnce(&mut Database) -> T, T>(&self, f: F) -> T {
+        f(&mut self.db.write().unwrap())
+    }
+
     /// Get the first face for a font
     ///
     /// Assumes that `font_id` is valid; if not the method will panic.
@@ -227,7 +239,7 @@ impl FontLibrary {
         drop(fonts);
 
         let mut faces = Vec::new();
-        selector.select(&self.db, |source, index| {
+        selector.select(&self.db.read().unwrap(), |source, index| {
             Ok(faces.push(match source {
                 fontdb::Source::Binary(_) => unimplemented!(),
                 fontdb::Source::File(path) => self.load_path(path, index),
@@ -405,7 +417,7 @@ impl FontLibrary {
     // Private because: safety depends on instance(s) never being destructed.
     fn new() -> Self {
         FontLibrary {
-            db: selector::Database::new(),
+            db: RwLock::new(Database::new()),
             data: Default::default(),
             faces: Default::default(),
             fonts: Default::default(),

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -20,7 +20,7 @@ enum FontError {
     NotFound,
     #[error("font load error")]
     TtfParser(#[from] ttf_parser::FaceParsingError),
-    #[cfg(feature = "rustybuzz")]
+    #[cfg(all(not(feature = "harfbuzz_rs"), feature = "rustybuzz"))]
     #[error("unknown font read error")]
     UnknownLoadError,
 }

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -5,7 +5,7 @@
 
 //! Font library
 
-use super::{FaceRef, FontSelector};
+use super::{selector, FaceRef, FontSelector};
 use crate::conv::{to_u32, to_usize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -122,7 +122,7 @@ impl FontList {
 /// This is the type of the global singleton accessible via the [`fonts`]
 /// function. Thread-safety is handled via internal locks.
 pub struct FontLibrary {
-    db: fontdb::Database,
+    db: selector::Database,
     // Font files loaded into memory. Safety: we assume that existing entries
     // are never modified or removed (though the Vec is allowed to reallocate).
     // Note: using std::pin::Pin does not help since u8 impls Unpin.
@@ -404,11 +404,8 @@ pub(crate) unsafe fn extend_lifetime<'b, T: ?Sized>(r: &'b T) -> &'static T {
 impl FontLibrary {
     // Private because: safety depends on instance(s) never being destructed.
     fn new() -> Self {
-        let mut db = fontdb::Database::new();
-        db.load_system_fonts();
-
         FontLibrary {
-            db,
+            db: selector::Database::new(),
             data: Default::default(),
             faces: Default::default(),
             fonts: Default::default(),

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -32,7 +32,7 @@ enum FontError {
 /// Internally this uses a numeric identifier, which is always less than
 /// [`FontLibrary::num_faces`], assuming that at least one font has been loaded.
 /// [`FontLibrary::face_data`] may be used to retrieve the matching font.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FaceId(pub u32);
 impl FaceId {
     /// Get as `usize`

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -9,11 +9,12 @@
 
 use super::families;
 use fontdb::{FaceInfo, Source};
-pub use fontdb::{Family, Stretch, Style, Weight};
+pub use fontdb::{Stretch, Style, Weight};
 use std::borrow::Cow;
 use std::collections::hash_map::{Entry, HashMap};
 
 /// How to add new aliases when others exist
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum AddMode {
     Prepend,
     Append,

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -87,30 +87,28 @@ impl Database {
     /// Add font aliases for family
     ///
     /// When searching for `family`, all `aliases` will be searched too.
-    pub fn add_aliases(
-        &mut self,
-        family: Cow<'static, str>,
-        mut aliases: Vec<Cow<'static, str>>,
-        mode: AddMode,
-    ) {
+    pub fn add_aliases<I>(&mut self, family: Cow<'static, str>, aliases: I, mode: AddMode)
+    where
+        I: Iterator<Item = Cow<'static, str>>,
+    {
         match self.aliases.entry(family) {
             Entry::Occupied(mut entry) => {
                 let existing = entry.get_mut();
                 match mode {
                     AddMode::Prepend => {
-                        aliases.extend(existing.drain(..));
-                        *existing = aliases;
+                        existing.splice(0..0, aliases);
                     }
                     AddMode::Append => {
-                        existing.extend(aliases.drain(..));
+                        existing.extend(aliases);
                     }
                     AddMode::Replace => {
-                        *existing = aliases;
+                        existing.clear();
+                        existing.extend(aliases);
                     }
                 }
             }
             Entry::Vacant(entry) => {
-                entry.insert(aliases);
+                entry.insert(aliases.collect());
             }
         }
     }

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -213,9 +213,11 @@ impl<'a> FontSelector<'a> {
         let mut i = 0;
         while i < families.len() {
             if let Some(aliases) = db.aliases.get(&families[i]) {
+                let mut j = i + 1;
                 for alias in aliases {
                     if !families.contains(alias) {
-                        families.push(alias.clone());
+                        families.insert(j, alias.clone());
+                        j += 1;
                     }
                 }
             }

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -15,6 +15,7 @@ use std::collections::hash_map::{Entry, HashMap};
 
 /// How to add new aliases when others exist
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AddMode {
     Prepend,
     Append,

--- a/src/format.rs
+++ b/src/format.rs
@@ -204,7 +204,7 @@ impl Clone for Box<dyn FormattableTextDyn> {
 }
 
 /// Font formatting token
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FontToken {
     /// Index in text at which formatting becomes active
     ///

--- a/src/format/markdown.rs
+++ b/src/format/markdown.rs
@@ -7,7 +7,7 @@
 
 use super::{EditableText, FontToken, FormattableText};
 use crate::conv::to_u32;
-use crate::fonts::{self, Family, FontId, FontSelector, Style, Weight};
+use crate::fonts::{self, FontId, FontSelector, Style, Weight};
 #[cfg(not(feature = "gat"))]
 use crate::OwningVecIter;
 use crate::{Effect, EffectFlags};
@@ -202,7 +202,7 @@ fn parse(input: &str) -> Result<Markdown, Error> {
                 item.start = to_u32(text.len());
 
                 let mut item2 = item.clone();
-                item2.sel.set_families(vec![Family::Monospace]);
+                item2.sel.set_families(vec!["monospace".into()]);
                 set_last(&item2);
 
                 text.push_str(&part);
@@ -357,7 +357,7 @@ impl StackItem {
             Tag::CodeBlock(_) => {
                 state.start_block(text);
                 self.start = to_u32(text.len());
-                with_clone(self, |item| item.sel.set_families(vec![Family::Monospace]))
+                with_clone(self, |item| item.sel.set_families(vec!["monospace".into()]))
                 // TODO: within a code block, the last \n should be suppressed?
             }
             Tag::List(start) => {

--- a/src/text.rs
+++ b/src/text.rs
@@ -221,6 +221,7 @@ impl<T: FormattableText> TextApi for Text<T> {
             &self.text,
             self.env.flags.contains(EnvFlags::BIDI),
             self.env.dir,
+            self.env.font_id,
             self.env.dpp,
             self.env.pt_size,
         );


### PR DESCRIPTION
This PR changes font selection from using fixed family lists to using configurable aliases, thus supporting run-time configuration.

Also adds `font_id` to the `Environment` struct, thus supporting custom font usage without formatting tokens.