### PR TITLE
[breaking] Add raster module, easy-cast dep, use dpem for scale

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ gat = []
 # serde: enable (de)serialization for a few types
 
 [dependencies]
+easy-cast = "0.4.2"
 bitflags = "1.2.1"
 fontdb = "0.5.4"
 ttf-parser = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,15 @@ markdown = ["pulldown-cmark"]
 # Use Generic Associated Types (experimental)
 gat = []
 
-# Also:
-# serde: enable (de)serialization for a few types
+# Serialization is optionally supported for some types:
+# serde
+
+# Glyph rastering is optionally supported (requires at least one of the following):
+# ab_glyph
+# fontdue
 
 [dependencies]
+cfg-if = "1.0.0"
 easy-cast = "0.4.2"
 bitflags = "1.2.1"
 fontdb = "0.5.4"
@@ -41,6 +46,8 @@ thiserror = "1.0.20"
 pulldown-cmark = { version = "0.8.0", optional = true }
 log = "0.4"
 serde = { version = "1.0.123", features = ["derive"], optional = true }
+ab_glyph = { version = "0.2.10", optional = true }
+fontdue = { version = "0.5.2", optional = true }
 
 [dependencies.rustybuzz]
 version = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-text"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -27,7 +27,9 @@ gat = []
 # Serialization is optionally supported for some types:
 # serde
 
-# Glyph rastering is optionally supported (requires at least one of the following):
+# Glyph rastering is optionally supported; "raster" uses the default backend
+# or a backend may be specified directly:
+raster = ["ab_glyph"]
 # ab_glyph
 # fontdue
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -10,7 +10,7 @@
 //! and our text representations are not intended to scale anywhere close to
 //! `u32::MAX` bytes of text, so `u32` is always an appropriate index type).
 
-use std::mem::size_of;
+use easy_cast::Cast;
 
 /// Convert `usize` → `u32`
 ///
@@ -18,19 +18,7 @@ use std::mem::size_of;
 /// input value may be represented correctly by `u32`.
 #[inline]
 pub fn to_u32(x: usize) -> u32 {
-    debug_assert!(x <= to_usize(u32::MAX));
-    x as u32
-}
-
-// Borrowed from static_assertions:
-macro_rules! const_assert {
-    ($x:expr $(,)?) => {
-        #[allow(unknown_lints, eq_op)]
-        const _: [(); 0 - !{
-            const ASSERT: bool = $x;
-            ASSERT
-        } as usize] = [];
-    };
+    x.cast()
 }
 
 /// Convert `u32` → `usize`
@@ -39,8 +27,7 @@ macro_rules! const_assert {
 /// zero-extension.
 #[inline]
 pub fn to_usize(x: u32) -> usize {
-    const_assert!(size_of::<usize>() >= size_of::<u32>());
-    x as usize
+    x.cast()
 }
 
 /// Scale factor: pixels per font unit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 mod env;
 pub use env::*;
 
-pub mod conv;
+mod conv;
 
 mod data;
 pub use data::{Range, Vec2};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,17 +6,10 @@
 //! KAS-text: text layout library
 //!
 //! KAS-text supports plain text input, custom formatted text objects (see the
-//! [`format`] module) and a subset of Markdown ([`format::Markdown`]).
+//! [`format`] module) and a subset of Markdown ([`format::Markdown`],
+//! feature-gated).
 //!
-//! This library supports the following feature flags:
-//!
-//! -   `shaping`: enable complex text shaping via the Harfbuzz library (this is
-//!     optional since the built-in alternative works sufficiently well for most
-//!     languages)
-//! -   `markdown`: enable Markdown parsing via `pulldown-cmark`
-//! -   `gat`: experimental API improvements using Generic Associated Types;
-//!     since Rust's support for this is incomplete, it should be considered no
-//!     more than an API preview and usage is not recommended in practice
+//! The library also supports glyph rastering (depending on feature flags).
 //!
 //! [`format`]: mod@format
 
@@ -36,6 +29,9 @@ pub use display::*;
 
 pub mod fonts;
 pub mod format;
+
+#[cfg(any(feature = "ab_glyph", feature = "fontdue"))]
+pub mod raster;
 
 mod text;
 pub use text::*;

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -1,0 +1,200 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Support for rastering glyphs
+//!
+//! This module is only available if `ab_glyph`, `fontdue` or both features are
+//! enabled.
+
+use crate::conv::DPU;
+use crate::fonts::{fonts, FaceId};
+use crate::{Glyph, GlyphId};
+use easy_cast::*;
+
+/// Raster configuration
+pub struct Config {
+    #[allow(unused)]
+    sb_align: bool,
+    #[allow(unused)]
+    fontdue: bool,
+    scale_steps: f32,
+    subpixel_threshold: f32,
+    subpixel_steps: f32,
+}
+
+impl Config {
+    pub fn new(mode: u8, scale_steps: u8, subpixel_threshold: u8, subpixel_steps: u8) -> Self {
+        Config {
+            sb_align: mode == 1,
+            fontdue: mode == 2,
+            scale_steps: scale_steps.cast(),
+            subpixel_threshold: subpixel_threshold.cast(),
+            subpixel_steps: subpixel_steps.cast(),
+        }
+    }
+}
+
+/// A rastered sprite
+pub struct Sprite {
+    pub offset: (i32, i32),
+    pub size: (u32, u32),
+    pub data: Vec<u8>,
+}
+
+/// A Sprite descriptor
+///
+/// This descriptor includes all important properties of a rastered glyph in a
+/// small, easily hashable value. It is thus ideal for caching rastered glyphs
+/// in a `HashMap`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct SpriteDescriptor(u64);
+
+impl SpriteDescriptor {
+    /// Choose a sub-pixel precision multiplier based on the height
+    ///
+    /// Must return an integer between 1 and 16.
+    fn sub_pixel_from_height(config: &Config, height: f32) -> f32 {
+        if height < config.subpixel_threshold {
+            config.subpixel_steps
+        } else {
+            1.0
+        }
+    }
+
+    /// Construct
+    pub fn new(config: &Config, face: FaceId, glyph: Glyph, height: f32) -> Self {
+        let face: u16 = face.get().cast();
+        let glyph_id: u16 = glyph.id.0;
+        let mult = Self::sub_pixel_from_height(config, height);
+        let mult2 = 0.5 * mult;
+        let steps = u8::conv_nearest(mult);
+        let height: u32 = (height * config.scale_steps).cast_nearest();
+        let x_off = u8::conv_floor(glyph.position.0.fract() * mult + mult2) % steps;
+        let y_off = u8::conv_floor(glyph.position.1.fract() * mult + mult2) % steps;
+        assert!(height & 0xFF00_0000 == 0 && x_off & 0xF0 == 0 && y_off & 0xF0 == 0);
+        let packed = face as u64
+            | ((glyph_id as u64) << 16)
+            | ((height as u64) << 32)
+            | ((x_off as u64) << 56)
+            | ((y_off as u64) << 60);
+        SpriteDescriptor(packed)
+    }
+
+    /// Get `FaceId` descriptor
+    pub fn face(self) -> FaceId {
+        FaceId((self.0 & 0x0000_0000_0000_FFFF).cast())
+    }
+
+    /// Get `GlyphId` descriptor
+    pub fn glyph(self) -> GlyphId {
+        GlyphId(((self.0 & 0x0000_0000_FFFF_0000) >> 16).cast())
+    }
+
+    /// Get scale (height in pixels)
+    pub fn height(self, config: &Config) -> f32 {
+        let height = ((self.0 & 0x00FF_FFFF_0000_0000) >> 32) as u32;
+        f32::conv(height) / config.scale_steps
+    }
+
+    /// Get fractional position
+    ///
+    /// This may optionally be used (depending on [`Config`]) to improve letter
+    /// spacing at small font sizes. Returns the `(x, y)` offsets in the range
+    /// `0.0 ≤ x < 1.0` (and the same for `y`).
+    pub fn fractional_position(self, config: &Config) -> (f32, f32) {
+        let mult = 1.0 / Self::sub_pixel_from_height(config, self.height(config));
+        let x = ((self.0 & 0x0F00_0000_0000_0000) >> 56) as u8;
+        let y = ((self.0 & 0xF000_0000_0000_0000) >> 60) as u8;
+        let x = f32::conv(x) * mult;
+        let y = f32::conv(y) * mult;
+        (x, y)
+    }
+}
+
+#[cfg(feature = "ab_glyph")]
+fn raster_ab(config: &Config, dpu: DPU, desc: SpriteDescriptor) -> Option<Sprite> {
+    use crate::fonts::FaceRef;
+    use ab_glyph::Font;
+
+    let id = desc.glyph();
+    let face = desc.face();
+    let face_store = fonts().get_face_store(face);
+
+    let (mut x, y) = desc.fractional_position(config);
+    let glyph_off = (x.round(), y.round());
+    if config.sb_align && desc.height(config) >= config.subpixel_threshold {
+        let sf = FaceRef(&face_store.face).scale_by_dpu(dpu);
+        x -= sf.h_side_bearing(id);
+    }
+
+    let glyph = ab_glyph::Glyph {
+        id: ab_glyph::GlyphId(id.0),
+        scale: desc.height(config).into(),
+        position: ab_glyph::point(x, y),
+    };
+    let outline = face_store.ab_glyph.outline_glyph(glyph)?;
+
+    let bounds = outline.px_bounds();
+    let offset = (bounds.min.x - glyph_off.0, bounds.min.y - glyph_off.1);
+    let offset = (offset.0.cast_trunc(), offset.1.cast_trunc());
+    let size = bounds.max - bounds.min;
+    let size = (u32::conv_trunc(size.x), u32::conv_trunc(size.y));
+    if size.0 == 0 || size.1 == 0 {
+        log::warn!("Zero-sized glyph: {:?}", desc.glyph());
+        return None; // nothing to draw
+    }
+
+    let mut data = Vec::new();
+    data.resize(usize::conv(size.0 * size.1), 0u8);
+    outline.draw(|x, y, c| {
+        // Convert to u8 with saturating conversion, rounding down:
+        data[usize::conv((y * size.0) + x)] = (c * 256.0) as u8;
+    });
+
+    Some(Sprite { offset, size, data })
+}
+
+#[cfg(feature = "fontdue")]
+fn raster_fontdue(dpu: DPU, desc: SpriteDescriptor) -> Option<Sprite> {
+    let face = desc.face();
+    let face = &fonts().get_face_store(face).fontdue;
+
+    // Ironically fontdue uses DPU internally, but doesn't let us input that.
+    let px_per_em = dpu.0 * face.units_per_em();
+    let (metrics, data) = face.rasterize_indexed(desc.glyph().0.cast(), px_per_em);
+
+    let size = (u32::conv(metrics.width), u32::conv(metrics.height));
+    let h_off = -metrics.ymin - i32::conv(metrics.height);
+    let offset = (metrics.xmin, h_off);
+    if size.0 == 0 || size.1 == 0 {
+        log::warn!("Zero-sized glyph: {:?}", desc.glyph());
+        return None; // nothing to draw
+    }
+
+    Some(Sprite { offset, size, data })
+}
+
+/// Raster a glyph
+///
+/// Attempts to raster a glyph. Can fail, in which case `None` is returned.
+///
+/// On success, returns the glyph offset (to be added to the sprite position
+/// when rendering), the glyph size, and the rastered glyph (row-major order).
+pub fn raster(dpu: DPU, config: &Config, desc: SpriteDescriptor) -> Option<Sprite> {
+    cfg_if::cfg_if! {
+        if #[cfg(all(feature = "fontdue", feature = "ab_glyph"))] {
+            if config.fontdue {
+                raster_fontdue(dpu, desc)
+            } else {
+                raster_ab(config, dpu, desc)
+            }
+        } else if #[cfg(feature = "ab_glyph")] {
+            raster_ab(config, dpu, desc)
+        } else {
+            let _ = config;
+            raster_fontdue(dpu, desc)
+        }
+    }
+}

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -79,6 +79,7 @@ pub(crate) struct GlyphRun {
     pub range: Range,
     /// Font size (pixels/em)
     pub dpem: f32,
+    pub dpu: DPU,
     /// Font face identifier
     pub face_id: FaceId,
     /// Tab or no-break property
@@ -93,10 +94,6 @@ pub(crate) struct GlyphRun {
     /// Note: it would be equivalent to use a separate `Run` for each sub-range
     /// in the text instead of tracking breaks via this field.
     pub breaks: SmallVec<[GlyphBreak; 5]>,
-
-    pub dpu: DPU,
-    /// Text height in pixels (stored for compat with glyph_brush downstream)
-    pub height: f32,
 
     /// End position, excluding whitespace
     ///
@@ -292,14 +289,13 @@ pub(crate) fn shape(
     GlyphRun {
         range,
         dpem,
+        dpu,
         face_id,
         special,
         level,
 
         glyphs,
         breaks,
-        dpu,
-        height: sf.height(),
         no_space_end,
         caret,
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -7,7 +7,6 @@
 
 use std::convert::{AsMut, AsRef};
 
-use crate::conv::DPU;
 use crate::display::{Effect, MarkerPosIter, TextDisplay};
 use crate::fonts::FaceId;
 use crate::format::{EditableText, FormattableText};
@@ -343,7 +342,7 @@ pub trait TextApiExt: TextApi {
     /// Yield a sequence of positioned glyphs
     ///
     /// Wraps [`TextDisplay::glyphs`].
-    fn glyphs<F: FnMut(FaceId, DPU, f32, Glyph)>(&self, f: F) {
+    fn glyphs<F: FnMut(FaceId, f32, Glyph)>(&self, f: F) {
         self.display().glyphs(f)
     }
 
@@ -353,7 +352,7 @@ pub trait TextApiExt: TextApi {
     fn glyphs_with_effects<X, F, G>(&self, effects: &[Effect<X>], default_aux: X, f: F, g: G)
     where
         X: Copy,
-        F: FnMut(FaceId, DPU, f32, Glyph, usize, X),
+        F: FnMut(FaceId, f32, Glyph, usize, X),
         G: FnMut(f32, f32, f32, f32, usize, X),
     {
         self.display()


### PR DESCRIPTION
It turned out the glyph raster logic used by KAS didn't have dependencies on anything else, so it makes sense to put it here, allowing re-use by any other library supporting text over KAS-text (CC #43).