### PR TITLE
0.3.1: always fall back to sans-serif + perf fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] — unreleased
+
+-   Make all families fall back to "sans-serif" fonts.
+
 ## [0.3.0] — 2021-06-15
 
 This release replaces all non-Rust dependencies allowing easier build/deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] — unreleased
+## [0.3.1] — 2021-06-17
 
 -   Make all families fall back to "sans-serif" fonts.
 -   Cache `FontLibrary::face_for_char` glyph lookups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.1] — unreleased
 
 -   Make all families fall back to "sans-serif" fonts.
+-   Cache `FontLibrary::face_for_char` glyph lookups.
 
 ## [0.3.0] — 2021-06-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-text"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/fonts/families.rs
+++ b/src/fonts/families.rs
@@ -22,7 +22,7 @@
 //!
 //! Font family ordering indicates usage preference.
 
-pub const DEFAULT_SERIF: [&'static str; 12] = [
+pub const DEFAULT_SERIF: &[&'static str] = &[
     "serif",
     "Palatino Linotype",
     "Palatino",
@@ -33,11 +33,10 @@ pub const DEFAULT_SERIF: [&'static str; 12] = [
     "Times",
     "Times CY",
     "DejaVu Serif",
-    "Jomolhari",
     "Liberation Serif",
 ];
 
-pub const DEFAULT_SANS_SERIF: [&'static str; 16] = [
+pub const DEFAULT_SANS_SERIF: &[&'static str] = &[
     "sans-serif",
     "Tahoma",
     "Noto Sans",
@@ -47,7 +46,6 @@ pub const DEFAULT_SANS_SERIF: [&'static str; 16] = [
     "Arial",
     "Arial Hebrew",
     "Verdana",
-    "Cantarell",
     "Vera Sans",
     "Roboto",
     "Lato",
@@ -56,7 +54,7 @@ pub const DEFAULT_SANS_SERIF: [&'static str; 16] = [
     "Lucida Sans Unicode",
 ];
 
-pub const DEFAULT_MONOSPACE: [&'static str; 18] = [
+pub const DEFAULT_MONOSPACE: &[&'static str] = &[
     "monospace",
     "Consolas",
     "Droid Sans Mono",
@@ -77,7 +75,7 @@ pub const DEFAULT_MONOSPACE: [&'static str; 18] = [
     "Courier",
 ];
 
-pub const DEFAULT_CURSIVE: [&'static str; 5] = [
+pub const DEFAULT_CURSIVE: &[&'static str] = &[
     "cursive",
     "Gabriola",
     "Segoe Script",
@@ -85,7 +83,7 @@ pub const DEFAULT_CURSIVE: [&'static str; 5] = [
     "Comic Sans MS",
 ];
 
-pub const DEFAULT_FANTASY: [&'static str; 5] = [
+pub const DEFAULT_FANTASY: &[&'static str] = &[
     "fantasy",
     "Segoe Print",
     "Impact",

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -209,9 +209,10 @@ impl<'a> FontSelector<'a> {
         // TODO(opt): improve, perhaps moving some computation earlier (e.g.
         // culling aliases which do not resolve fonts), and use faster alias expansion.
         let mut families: Vec<Cow<'b, str>> = self.families.clone();
-        if families.is_empty() {
-            // We allow an empty family list to resolve to SansSerif.
-            families.push("sans-serif".into());
+        let sans_serif = Cow::<'static, str>::from("sans-serif");
+        if !families.contains(&sans_serif) {
+            // All families fall back to sans-serif, ensuring we almost always have a usable font
+            families.push(sans_serif);
         }
 
         // Append aliases


### PR DESCRIPTION
This fixes a couple of issues that came up when trying to draw Arabic using a serif font: (a) we *have* to fall back to sans-serif fonts, and (b) repeated `glyph_index` lookups through several fallback fonts are quite slow, so use a cache.