### PR TITLE
0.3.2: minor optimisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] — 2021-06-30
+
+-   Minor optimisations to `SpriteDescriptor::new` (#53)
+
 ## [0.3.1] — 2021-06-17
 
 -   Make all families fall back to "sans-serif" fonts.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-text"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
These are small. We could probably do better by replacing `f32` with fixed-precision arithmetic, but that's not done here.