### PR TITLE
Prepare 0.3.3: raster doc, ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] — 2021-07-19
+
+-   Document `raster` module and `Markdown` formatter (#56)
+-   Export `DPU` (#56)
+-   `Default`, `Debug` and `PartialEq` impls for some `raster` types (#56)
+
 ## [0.3.2] — 2021-06-30
 
 -   Minor optimisations to `SpriteDescriptor::new` (#53)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,12 @@ categories = ["text-processing"]
 repository = "https://github.com/kas-gui/kas-text"
 exclude = ["design"]
 
+[package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --features markdown,raster --no-deps --open
+features = ["markdown", "raster"]
+rustdoc-args = ["--cfg", "doc_cfg"]
+
 [features]
 # Enable shaping with the default dependency.
 shaping = ["rustybuzz"]
@@ -58,9 +64,3 @@ optional = true
 [dependencies.harfbuzz_rs]
 version = "1.1.2"
 optional = true
-
-[package.metadata.docs.rs]
-# To build locally:
-# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --features markdown --no-deps --open
-features = ["markdown"]
-rustdoc-args = ["--cfg", "doc_cfg"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-text"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/fonts/mod.rs
+++ b/src/fonts/mod.rs
@@ -23,10 +23,10 @@
 //! ```
 //!
 //! (It is not technically necessary to lead the first font with
-//! [`FontLibrary::load_default`]; whichever font is loaded first has number 0.
-//! If doing this, `load_default` must not be called at all.
+//! [`FontLibrary::select_default`]; whichever font is loaded first has number 0.
+//! If doing this, `select_default` must not be called at all.
 //! It is harmless to attempt to load any font multiple times, whether with
-//! `load_default` or another method.)
+//! `select_default` or another method.)
 //!
 //! ### FaceId vs FontId
 //!
@@ -68,7 +68,7 @@
 //! Finally, note that digital font files have an internally defined unit
 //! known as the *font unit*. We introduce one final unit:
 //!
-//! -   [`crate::conv::DPU`]: pixels per font unit
+//! -   [`crate::DPU`]: pixels per font unit
 
 use crate::GlyphId;
 

--- a/src/format/markdown.rs
+++ b/src/format/markdown.rs
@@ -22,6 +22,30 @@ pub enum Error {
     NotSupported(&'static str),
 }
 
+/// Basic Markdown formatter
+///
+/// Currently this misses several important Markdown features, but may still
+/// prove a convenient way of constructing formatted texts.
+///
+/// Supported:
+///
+/// -   Text paragraphs
+/// -   Code (embedded and blocks); caveat: extra line after code blocks
+/// -   Explicit line breaks
+/// -   Headings
+/// -   Lists (numerated and bulleted); caveat: indentation after first line
+/// -   Bold, italic (emphasis), strikethrough
+///
+/// Not supported:
+///
+/// -   Block quotes
+/// -   Footnotes
+/// -   HTML
+/// -   Horizontal rules
+/// -   Images
+/// -   Links
+/// -   Tables
+/// -   Task lists
 #[derive(Clone, Debug, PartialEq)]
 pub struct Markdown {
     text: String,
@@ -30,6 +54,7 @@ pub struct Markdown {
 }
 
 impl Markdown {
+    /// Parse the input as Markdown
     #[inline]
     pub fn new(input: &str) -> Result<Self, Error> {
         parse(input)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod env;
 pub use env::*;
 
 mod conv;
+pub use conv::DPU;
 
 mod data;
 pub use data::{Range, Vec2};


### PR DESCRIPTION

-   Document `raster` module and `Markdown` formatter
-   Export `DPU`
-   `Default`, `Debug` and `PartialEq` impls for some `raster` types
