### PR TITLE
0.4.0: Expose fontdb, font loading control, update deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
           args: --all -- --check
       - name: doc
         run: RUSTDOCFLAGS="--cfg doc_cfg" cargo doc --features markdown --no-deps
+      - name: Test Harfbuzz
+        run: cargo test --features harfbuzz
 
   test:
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] — 2021-09-03
+
+This is a minor release (mostly non-breaking). The primary motivation is to
+enable `resvg` to access the loaded font database. See PR #58:
+
+-   **Breaking:** update dependencies: `bitflags = 1.3.1`, `fontdb = 0.6.0`,
+    `harfbuzz_rs = 2.0`, `rustybuzz = 0.4.0`
+-   Make `fontdb::Database` externally readable and set font families
+-   Additional control over loading fonts
+-   Performance improvements for alias lookups (trim and capitalise earlier)
+
 ## [0.3.4] — 2021-07-28
 
 -   Fix sub-pixel positioning (#57)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ raster = ["ab_glyph"]
 [dependencies]
 cfg-if = "1.0.0"
 easy-cast = "0.4.2"
-bitflags = "1.2.1"
-fontdb = "0.5.4"
+bitflags = "1.3.1"
+fontdb = "0.6.0"
 ttf-parser = "0.12.0"
 lazy_static = "1.4.0"
 smallvec = "1.6.1"
@@ -62,5 +62,5 @@ version = "0.3.0"
 optional = true
 
 [dependencies.harfbuzz_rs]
-version = "1.1.2"
+version = "2.0"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-text"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ ab_glyph = { version = "0.2.10", optional = true }
 fontdue = { version = "0.5.2", optional = true }
 
 [dependencies.rustybuzz]
-version = "0.3.0"
+version = "0.4.0"
 optional = true
 
 [dependencies.harfbuzz_rs]

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -254,14 +254,16 @@ impl FontLibrary {
 
     /// Select the default font
     ///
-    /// If `FontId(0)` has not been defined yet, this sets the default font,
-    /// otherwise it does nothing.
+    /// If the font database has not yet been initialised, it is initialised.
+    ///
+    /// If `FontId(0)` has not been defined yet, this sets the default font.
     ///
     /// This *must* be called (at least once) before any other font-loading
     /// method, and before querying any font-derived properties (such as text
     /// dimensions).
     #[inline]
     pub fn select_default(&self) -> Result<(), Box<dyn std::error::Error>> {
+        self.db.write().unwrap().init();
         if self.fonts.read().unwrap().fonts.is_empty() {
             let id = self.select_font(&FontSelector::default())?;
             debug_assert!(id == FontId::default());

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -165,6 +165,11 @@ pub struct FontLibrary {
 
 /// Font management
 impl FontLibrary {
+    /// Get a reference to the font database
+    pub fn read_db(&self) -> RwLockReadGuard<Database> {
+        self.db.read().unwrap()
+    }
+
     /// Get mutable access to the font database
     ///
     /// This can be used to adjust font selection. Note that any changes only

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -136,6 +136,22 @@ impl Database {
             .map(|result| result.iter().map(|s| s.as_ref()))
     }
 
+    /// Resolve the substituted font family name for this family
+    ///
+    /// The input must be upper case. The output will be the loaded font's case.
+    /// Example: `SANS-SERIF`
+    pub fn font_family_from_alias(&self, family: &str) -> Option<String> {
+        let families_upper = &self.families_upper;
+        let db = &self.db;
+        self.aliases
+            .get(family)
+            .and_then(|list| list.iter().next())
+            .map(|name| {
+                let index = *families_upper.get(name.as_ref()).unwrap();
+                db.faces()[index].family.clone()
+            })
+    }
+
     /// Add font aliases for family
     ///
     /// When searching for `family`, all `aliases` will be searched too. Both
@@ -260,6 +276,24 @@ impl Database {
                         i += 1;
                     }
                 }
+            }
+
+            // Set family names in DB (only used in case the DB is used
+            // externally, e.g. to render an SVG with resvg).
+            if let Some(name) = self.font_family_from_alias("SERIF") {
+                self.db.set_serif_family(name);
+            }
+            if let Some(name) = self.font_family_from_alias("SANS-SERIF") {
+                self.db.set_sans_serif_family(name);
+            }
+            if let Some(name) = self.font_family_from_alias("MONOSPACE") {
+                self.db.set_monospace_family(name);
+            }
+            if let Some(name) = self.font_family_from_alias("CURSIVE") {
+                self.db.set_cursive_family(name);
+            }
+            if let Some(name) = self.font_family_from_alias("FANTASY") {
+                self.db.set_fantasy_family(name);
             }
 
             self.state = State::Ready;

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -86,6 +86,30 @@ impl Database {
         }
     }
 
+    /// Access the database
+    pub fn db(&self) -> &fontdb::Database {
+        &self.db
+    }
+
+    /// Access the list of discovered font families
+    ///
+    /// All family names are uppercase.
+    pub fn families_upper(&self) -> impl Iterator<Item = &str> {
+        self.family_upper.iter().map(|s| s.as_str())
+    }
+
+    /// List all font family alias keys
+    pub fn alias_keys(&self) -> impl Iterator<Item = &str> {
+        self.aliases.keys().map(|k| k.as_ref())
+    }
+
+    /// List all aliases for the given family
+    pub fn aliases_of(&self, family: &str) -> Option<impl Iterator<Item = &str>> {
+        self.aliases
+            .get(family)
+            .map(|result| result.iter().map(|s| s.as_ref()))
+    }
+
     /// Add font aliases for family
     ///
     /// When searching for `family`, all `aliases` will be searched too.

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -245,6 +245,22 @@ impl Database {
                 .enumerate()
                 .map(|(i, face)| (face.family.to_uppercase(), i))
                 .collect();
+            let families_upper = &self.families_upper;
+
+            for aliases in self.aliases.values_mut() {
+                // Remove aliases to missing fonts:
+                aliases.retain(|name| families_upper.contains_key(name.as_ref()));
+
+                // Remove duplicates (this is O(n²), but n is usually small):
+                let mut i = 0;
+                while i < aliases.len() {
+                    if aliases[0..i].contains(&aliases[i]) {
+                        aliases.remove(i);
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
 
             self.state = State::Ready;
         }

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -14,6 +14,7 @@ pub use fontdb::{Stretch, Style, Weight};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::hash_map::{Entry, HashMap};
+use std::path::Path;
 
 /// How to add new aliases when others exist
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -137,6 +138,41 @@ impl Database {
                 entry.insert(aliases.collect());
             }
         }
+    }
+
+    /// Loads a font data into the `Database`.
+    ///
+    /// Will load all font faces in case of a font collection.
+    ///
+    /// Note: system fonts are loaded by default; this only augments the loaded
+    /// font collection.
+    pub fn load_font_data(&mut self, data: Vec<u8>) {
+        self.db.load_font_data(data);
+    }
+
+    /// Loads a font file into the `Database`.
+    ///
+    /// Will load all font faces in case of a font collection.
+    ///
+    /// Note: system fonts are loaded by default; this only augments the loaded
+    /// font collection.
+    pub fn load_font_file<P: AsRef<Path>>(&mut self, path: P) -> Result<(), std::io::Error> {
+        self.db.load_font_file(path)
+    }
+
+    /// Loads font files from the selected directory into the `Database`.
+    ///
+    /// This method will scan directories recursively.
+    ///
+    /// Will load `ttf`, `otf`, `ttc` and `otc` fonts.
+    ///
+    /// Unlike other `load_*` methods, this one doesn't return an error.
+    /// It will simply skip malformed fonts and will print a warning into the log for each of them.
+    ///
+    /// Note: system fonts are loaded by default; this only augments the loaded
+    /// font collection.
+    pub fn load_fonts_dir<P: AsRef<Path>>(&mut self, dir: P) {
+        self.db.load_fonts_dir(dir);
     }
 }
 

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -434,8 +434,8 @@ fn shape_rustybuzz(
         .zip(output.glyph_positions().iter())
     {
         let index = idx_offset + info.cluster;
-        assert!(info.codepoint <= u16::MAX as u32, "failed to map glyph id");
-        let id = GlyphId(info.codepoint as u16);
+        assert!(info.glyph_id <= u16::MAX as u32, "failed to map glyph id");
+        let id = GlyphId(info.glyph_id as u16);
 
         if breaks
             .get(break_i)


### PR DESCRIPTION
This will become 0.4.0:

-   **Breaking:** update dependencies: `bitflags = 1.3.1`, `fontdb = 0.6.0`,
    `harfbuzz_rs = 2.0`, `rustybuzz = 0.4.0`
-   Make `fontdb::Database` externally readable and set font families
-   Additional control over loading fonts
-   Performance improvements for alias lookups (trim and capitalise earlier)
