### PR TITLE
Breaking: return Result<T, NotReady> instead of panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] — unreleased
+
+-   Methods which previously panicked when "not ready" now return `Result<T, NotReady>`
+-   Remove `resize_runs` from API
+-   Change behaviour of `Text::prepare_lines` to prepare from scratch if necessary
+
 ## [0.4.2] — 2022-02-10
 
 -   Spellcheck documentation (#62)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-text"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/display.rs
+++ b/src/display.rs
@@ -134,7 +134,6 @@ impl TextDisplay {
         if action == Action::None {
             return None;
         }
-        self.action = Action::None;
 
         if action >= Action::All {
             let bidi = env.flags.contains(EnvFlags::BIDI);

--- a/src/display.rs
+++ b/src/display.rs
@@ -18,6 +18,13 @@ pub use glyph_pos::{Effect, EffectFlags, MarkerPos, MarkerPosIter};
 pub(crate) use text_runs::{LineRun, RunSpecial};
 use wrap_lines::{Line, RunPart};
 
+/// Error returned on operations if not ready
+///
+/// This error is returned if `prepare` must be called.
+#[derive(Clone, Copy, Default, Debug, thiserror::Error)]
+#[error("not ready")]
+pub struct NotReady;
+
 /// Text display, without source text representation
 ///
 /// In general, it is recommended to use [`crate::Text`] instead, which includes
@@ -115,9 +122,7 @@ impl TextDisplay {
     ///
     /// Required preparation actions are tracked internally, but cannot
     /// notice changes in the environment. In case the environment has changed
-    /// one should either call [`TextDisplay::require_action`] before this
-    /// method or use the [`TextDisplay::prepare_runs`],
-    /// [`TextDisplay::resize_runs`] and [`TextDisplay::prepare_lines`] methods.
+    /// one should either call [`TextDisplay::require_action`] before this method.
     ///
     /// Returns new size requirements, if an update action occurred. Returns
     /// `None` if no action was required (since requirements are computed as a
@@ -139,13 +144,18 @@ impl TextDisplay {
             self.resize_runs(text, env.dpp, env.pt_size);
         }
 
-        Some(self.prepare_lines(env.bounds, env.flags, env.align))
+        Some(
+            self.prepare_lines(env.bounds, env.flags, env.align)
+                .unwrap(),
+        )
     }
 
     /// Get the number of lines
-    pub fn num_lines(&self) -> usize {
-        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
-        self.lines.len()
+    pub fn num_lines(&self) -> Result<usize, NotReady> {
+        if !self.action.is_ready() {
+            return Err(NotReady);
+        }
+        Ok(self.lines.len())
     }
 
     /// Find the line containing text `index`
@@ -155,8 +165,14 @@ impl TextDisplay {
     /// Returns `None` in case `index` does not line on or at the end of a line
     /// (which means either that `index` is beyond the end of the text or that
     /// `index` is within a mult-byte line break).
-    pub fn find_line(&self, index: usize) -> Option<(usize, std::ops::Range<usize>)> {
-        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
+    pub fn find_line(
+        &self,
+        index: usize,
+    ) -> Result<Option<(usize, std::ops::Range<usize>)>, NotReady> {
+        if !self.action.is_ready() {
+            return Err(NotReady);
+        }
+
         let mut first = None;
         for (n, line) in self.lines.iter().enumerate() {
             if line.text_range.end() == index {
@@ -165,16 +181,18 @@ impl TextDisplay {
                 // lines it does not match any other location.
                 first = Some((n, line.text_range.to_std()));
             } else if line.text_range.includes(index) {
-                return Some((n, line.text_range.to_std()));
+                return Ok(Some((n, line.text_range.to_std())));
             }
         }
-        first
+        Ok(first)
     }
 
     /// Get the range of a line, by line number
-    pub fn line_range(&self, line: usize) -> Option<std::ops::Range<usize>> {
-        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
-        self.lines.get(line).map(|line| line.text_range.to_std())
+    pub fn line_range(&self, line: usize) -> Result<Option<std::ops::Range<usize>>, NotReady> {
+        if !self.action.is_ready() {
+            return Err(NotReady);
+        }
+        Ok(self.lines.get(line).map(|line| line.text_range.to_std()))
     }
 
     /// Get the directionality of the current line
@@ -182,11 +200,13 @@ impl TextDisplay {
     /// Returns `true` for left-to-right lines, `false` for RTL.
     ///
     /// Panics if `line >= self.num_lines()`.
-    pub fn line_is_ltr(&self, line: usize) -> bool {
-        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
+    pub fn line_is_ltr(&self, line: usize) -> Result<bool, NotReady> {
+        if !self.action.is_ready() {
+            return Err(NotReady);
+        }
         let first_run = self.lines[line].run_range.start();
         let glyph_run = to_usize(self.wrapped_runs[first_run].glyph_run);
-        self.runs[glyph_run].level.is_ltr()
+        Ok(self.runs[glyph_run].level.is_ltr())
     }
 
     /// Get the directionality of the current line
@@ -195,9 +215,8 @@ impl TextDisplay {
     ///
     /// Panics if `line >= self.num_lines()`.
     #[inline]
-    pub fn line_is_rtl(&self, line: usize) -> bool {
-        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
-        !self.line_is_ltr(line)
+    pub fn line_is_rtl(&self, line: usize) -> Result<bool, NotReady> {
+        self.line_is_ltr(line).map(|is_ltr| !is_ltr)
     }
 
     /// Find the text index for the glyph nearest the given `pos`
@@ -207,8 +226,10 @@ impl TextDisplay {
     ///
     /// Note: if the font's `rect` does not start at the origin, then its top-left
     /// coordinate should first be subtracted from `pos`.
-    pub fn text_index_nearest(&self, pos: Vec2) -> usize {
-        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
+    pub fn text_index_nearest(&self, pos: Vec2) -> Result<usize, NotReady> {
+        if !self.action.is_ready() {
+            return Err(NotReady);
+        }
         let mut n = 0;
         for (i, line) in self.lines.iter().enumerate() {
             if line.top > pos.1 {
@@ -217,17 +238,20 @@ impl TextDisplay {
             n = i;
         }
         // Expected to return Some(..) value but None has been observed:
-        self.line_index_nearest(n, pos.0).unwrap_or(0)
+        self.line_index_nearest(n, pos.0)
+            .map(|opt_line| opt_line.unwrap_or(0))
     }
 
     /// Find the text index nearest horizontal-coordinate `x` on `line`
     ///
     /// This is similar to [`TextDisplay::text_index_nearest`], but allows the
     /// line to be specified explicitly. Returns `None` only on invalid `line`.
-    pub fn line_index_nearest(&self, line: usize, x: f32) -> Option<usize> {
-        assert!(self.action.is_ready(), "kas-text::TextDisplay: not ready");
+    pub fn line_index_nearest(&self, line: usize, x: f32) -> Result<Option<usize>, NotReady> {
+        if !self.action.is_ready() {
+            return Err(NotReady);
+        }
         if line >= self.lines.len() {
-            return None;
+            return Ok(None);
         }
         let line = &self.lines[line];
         let run_range = line.run_range.to_std();
@@ -270,6 +294,6 @@ impl TextDisplay {
             try_best((end_pos - rel_pos).abs(), end_index);
         }
 
-        Some(to_usize(best))
+        Ok(Some(to_usize(best)))
     }
 }

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -5,7 +5,7 @@
 
 //! Text preparation: wrapping
 
-use super::{RunSpecial, TextDisplay};
+use super::{NotReady, RunSpecial, TextDisplay};
 use crate::conv::{to_u32, to_usize};
 use crate::fonts::{fonts, FontLibrary};
 use crate::shaper::GlyphRun;
@@ -44,15 +44,19 @@ impl TextDisplay {
     ///
     /// This does text layout, with wrapping if enabled.
     ///
-    /// Prerequisites: prepared runs: panics if action is greater than `Action::Wrap`.  
-    /// Post-requirements: none (`Action::None`).  
-    /// Parameters: see [`crate::Environment`] documentation.  
+    /// Prerequisites: prepared runs: errors if action is greater than `Action::Wrap`.
+    /// Post-requirements: none (`Action::None`).
+    /// Parameters: see [`crate::Environment`] documentation.
     /// Returns: required size, in pixels.
-    pub fn prepare_lines(&mut self, bounds: Vec2, flags: EnvFlags, align: (Align, Align)) -> Vec2 {
-        assert!(
-            self.action <= Action::Wrap,
-            "kas-text::TextDisplay: runs not prepared"
-        );
+    pub fn prepare_lines(
+        &mut self,
+        bounds: Vec2,
+        flags: EnvFlags,
+        align: (Align, Align),
+    ) -> Result<Vec2, NotReady> {
+        if self.action > Action::Wrap {
+            return Err(NotReady);
+        }
         self.action = Action::None;
 
         let wrap = flags.contains(EnvFlags::WRAP);
@@ -183,7 +187,7 @@ impl TextDisplay {
         self.lines = adder.lines;
         self.num_glyphs = adder.num_glyphs;
         self.width = bounds.0;
-        required
+        Ok(required)
     }
 }
 


### PR DESCRIPTION
Motivation: KAS will currently panic when attempting to draw text which did not have layout resolved first, since text preparation happens during layout calculation. Silent failure is preferable there.

Likely more changes will land before 0.5 is released.