### PR TITLE
Adjust API: Environment is Copy; prepare returns bool

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -102,6 +102,11 @@ impl Range {
         to_usize(self.end)
     }
 
+    /// True if the range is empty
+    pub fn is_empty(self) -> bool {
+        self.start >= self.end
+    }
+
     /// The number of iterable items, as `usize`
     pub fn len(self) -> usize {
         to_usize(self.end) - to_usize(self.start)

--- a/src/display.rs
+++ b/src/display.rs
@@ -144,6 +144,21 @@ impl TextDisplay {
         Ok(self.lines.len())
     }
 
+    /// Get the required height
+    pub fn height(&self) -> Result<f32, NotReady> {
+        if self.action > Action::VAlign {
+            return Err(NotReady);
+        }
+
+        if self.lines.is_empty() {
+            return Ok(0.0);
+        }
+
+        let top = self.lines.first().unwrap().top;
+        let bottom = self.lines.last().unwrap().bottom;
+        Ok(bottom - top)
+    }
+
     /// Find the line containing text `index`
     ///
     /// Returns the line number and the text-range of the line.

--- a/src/display.rs
+++ b/src/display.rs
@@ -145,6 +145,10 @@ impl TextDisplay {
     }
 
     /// Get the size of the required bounding box
+    ///
+    /// This is the position of the lower-right corner of a bounding box on
+    /// content after alignment, which is done using the input bounds. This is
+    /// only the minimum size requirement when top-left alignment is used.
     pub fn bounding_box(&self) -> Result<Vec2, NotReady> {
         if self.action > Action::VAlign {
             return Err(NotReady);

--- a/src/display.rs
+++ b/src/display.rs
@@ -149,7 +149,7 @@ impl TextDisplay {
         )
     }
 
-    /// Get the number of lines
+    /// Get the number of lines (after wrapping)
     pub fn num_lines(&self) -> Result<usize, NotReady> {
         if !self.action.is_ready() {
             return Err(NotReady);

--- a/src/display.rs
+++ b/src/display.rs
@@ -50,7 +50,7 @@ pub struct NotReady;
 ///
 ///     Each run is then fed through the text shaper, resulting in a sequence of
 ///     type-set glyphs.
-/// 2.  Optionally, [`Self::max_line_length`] may be used to calculate the
+/// 2.  Optionally, [`Self::measure_width`] may be used to calculate the
 ///     required width (mostly useful for short texts which will not wrap).
 /// 3.  [`Self::prepare_lines`] takes the output of the first step and
 ///     applies line wrapping, line re-ordering (for bi-directional lines) and
@@ -205,8 +205,7 @@ impl TextDisplay {
     /// - `Ok(Some(line_is_right_to_left))` otherwise
     ///
     /// Note: indeterminate lines (e.g. empty lines) have their direction
-    /// determined from the passed environment; in the case of
-    /// [`Direction::Auto`] this resolves to left-to-right.
+    /// determined from the passed environment, by default left-to-right.
     pub fn line_is_rtl(&self, line: usize) -> Result<Option<bool>, NotReady> {
         if !self.action.is_ready() {
             return Err(NotReady);

--- a/src/display.rs
+++ b/src/display.rs
@@ -137,10 +137,10 @@ impl TextDisplay {
 
         if action >= Action::All {
             let bidi = env.flags.contains(EnvFlags::BIDI);
-            self.prepare_runs(text, bidi, env.dir, env.font_id, env.dpp, env.pt_size);
+            self.prepare_runs(text, bidi, env.dir, env.font_id, env.dpem);
         } else if action == Action::Resize {
             // Note: this is only needed if we didn't just call prepare_runs()
-            self.resize_runs(text, env.dpp, env.pt_size);
+            self.resize_runs(text, env.dpem);
         }
 
         Some(

--- a/src/display.rs
+++ b/src/display.rs
@@ -9,7 +9,7 @@ use smallvec::SmallVec;
 
 use crate::conv::to_usize;
 use crate::format::FormattableText;
-use crate::{shaper, Action, EnvFlags, Environment, Vec2};
+use crate::{shaper, Action, Environment, Vec2};
 
 mod glyph_pos;
 mod text_runs;
@@ -136,8 +136,7 @@ impl TextDisplay {
         }
 
         if action >= Action::All {
-            let bidi = env.flags.contains(EnvFlags::BIDI);
-            self.prepare_runs(text, bidi, env.dir, env.font_id, env.dpem);
+            self.prepare_runs(text, env.direction, env.font_id, env.dpem);
         } else if action == Action::Resize {
             // Note: this is only needed if we didn't just call prepare_runs()
             self.resize_runs(text, env.dpem);

--- a/src/display.rs
+++ b/src/display.rs
@@ -102,7 +102,7 @@ pub struct TextDisplay {
     lines: Vec<Line>,
     num_glyphs: u32,
     /// Required for `highlight_lines`; may remove later:
-    width: f32,
+    r_bound: f32,
 }
 
 impl Default for TextDisplay {
@@ -114,7 +114,7 @@ impl Default for TextDisplay {
             wrapped_runs: Default::default(),
             lines: Default::default(),
             num_glyphs: 0,
-            width: 0.0,
+            r_bound: 0.0,
         }
     }
 }
@@ -144,19 +144,19 @@ impl TextDisplay {
         Ok(self.lines.len())
     }
 
-    /// Get the required height
-    pub fn height(&self) -> Result<f32, NotReady> {
+    /// Get the size of the required bounding box
+    pub fn bounding_box(&self) -> Result<Vec2, NotReady> {
         if self.action > Action::VAlign {
             return Err(NotReady);
         }
 
         if self.lines.is_empty() {
-            return Ok(0.0);
+            return Ok(Vec2::ZERO);
         }
 
         let top = self.lines.first().unwrap().top;
         let bottom = self.lines.last().unwrap().bottom;
-        Ok(bottom - top)
+        Ok(Vec2(self.r_bound, bottom - top))
     }
 
     /// Find the line containing text `index`

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -507,7 +507,7 @@ impl TextDisplay {
 
         let mut lines = self.lines.iter();
         let mut rects = Vec::with_capacity(self.lines.len());
-        let rbound = self.width;
+        let rbound = self.r_bound;
 
         // Find the first line
         let mut cur_line = 'l1: loop {

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -247,7 +247,7 @@ impl TextDisplay {
     /// ```no_run
     /// # use kas_text::{Glyph, Text, Environment, TextApi, TextApiExt};
     /// # fn draw(_: Vec<(f32, Glyph)>) {}
-    /// let mut text = Text::new_single("Some example text");
+    /// let mut text = Text::new("Some example text");
     /// text.prepare();
     ///
     /// let mut glyphs = Vec::with_capacity(text.num_glyphs());

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -5,13 +5,18 @@
 
 //! Methods using positioned glyphs
 
+#![allow(clippy::collapsible_else_if)]
+#![allow(clippy::or_fun_call)]
+#![allow(clippy::never_loop)]
+#![allow(clippy::needless_range_loop)]
+
 use super::{NotReady, TextDisplay};
 use crate::conv::to_usize;
 use crate::fonts::{fonts, FaceId, ScaledFaceRef};
 use crate::{Glyph, Vec2};
 
 /// Effect formatting marker
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Effect<X> {
     /// Index in text at which formatting becomes active
@@ -328,7 +333,7 @@ impl TextDisplay {
 
         // self.wrapped_runs is in logical order
         for run_part in self.wrapped_runs.iter().cloned() {
-            if run_part.glyph_range.len() == 0 {
+            if run_part.glyph_range.is_empty() {
                 continue;
             }
 
@@ -496,7 +501,7 @@ impl TextDisplay {
             return Err(NotReady);
         }
 
-        if range.len() == 0 {
+        if range.is_empty() {
             return Ok(vec![]);
         }
 
@@ -506,7 +511,7 @@ impl TextDisplay {
 
         // Find the first line
         let mut cur_line = 'l1: loop {
-            while let Some(line) = lines.next() {
+            for line in lines.by_ref() {
                 if line.text_range.includes(range.start) {
                     break 'l1 line;
                 }
@@ -550,7 +555,7 @@ impl TextDisplay {
         }
 
         if range.end > cur_line.text_range.end() {
-            while let Some(line) = lines.next() {
+            for line in lines {
                 if range.end <= line.text_range.end() {
                     cur_line = line;
                     break;
@@ -593,7 +598,7 @@ impl TextDisplay {
             return Err(NotReady);
         }
 
-        if range.len() == 0 {
+        if range.is_empty() {
             return Ok(vec![]);
         }
 

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -262,8 +262,6 @@ impl TextDisplay {
     ///
     /// This method has fairly low cost: `O(n)` in the number of glyphs with
     /// low overhead.
-    ///
-    /// One must call [`TextDisplay::prepare`] before this method.
     pub fn glyphs<F: FnMut(FaceId, f32, Glyph)>(&self, mut f: F) -> Result<(), NotReady> {
         if !self.action.is_ready() {
             return Err(NotReady);

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -47,7 +47,7 @@ impl TextDisplay {
         self.action = Action::Wrap;
         let mut dpem = dpp * pt_size;
 
-        let mut font_tokens = text.font_tokens(dpp, pt_size);
+        let mut font_tokens = text.font_tokens(dpem);
         let mut next_fmt = font_tokens.next();
 
         for run in &mut self.runs {
@@ -114,7 +114,7 @@ impl TextDisplay {
 
         let mut dpem = dpp * pt_size;
 
-        let mut font_tokens = text.font_tokens(dpp, pt_size);
+        let mut font_tokens = text.font_tokens(dpem);
         let mut next_fmt = font_tokens.next();
         if let Some(fmt) = next_fmt.as_ref() {
             if fmt.start == 0 {

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -42,10 +42,9 @@ impl TextDisplay {
     /// Prerequisites: prepared runs: requires action is no greater than `Action::Wrap`.
     /// Post-requirements: prepare lines (requires action `Action::Wrap`).  
     /// Parameters: see [`crate::Environment`] documentation.
-    pub(crate) fn resize_runs<F: FormattableText>(&mut self, text: &F, dpp: f32, pt_size: f32) {
+    pub(crate) fn resize_runs<F: FormattableText>(&mut self, text: &F, mut dpem: f32) {
         assert!(self.action <= Action::Resize);
         self.action = Action::Wrap;
-        let mut dpem = dpp * pt_size;
 
         let mut font_tokens = text.font_tokens(dpem);
         let mut next_fmt = font_tokens.next();
@@ -93,12 +92,11 @@ impl TextDisplay {
         bidi: bool,
         dir: Direction,
         mut font_id: FontId,
-        dpp: f32,
-        pt_size: f32,
+        mut dpem: f32,
     ) {
         match self.action {
             Action::None | Action::Wrap => return,
-            Action::Resize => return self.resize_runs(text, dpp, pt_size),
+            Action::Resize => return self.resize_runs(text, dpem),
             Action::All => (),
         }
         self.action = Action::Wrap;
@@ -111,8 +109,6 @@ impl TextDisplay {
 
         self.runs.clear();
         self.line_runs.clear();
-
-        let mut dpem = dpp * pt_size;
 
         let mut font_tokens = text.font_tokens(dpem);
         let mut next_fmt = font_tokens.next();

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -42,7 +42,7 @@ impl TextDisplay {
     /// Prerequisites: prepared runs: requires action is no greater than `Action::Wrap`.
     /// Post-requirements: prepare lines (requires action `Action::Wrap`).  
     /// Parameters: see [`crate::Environment`] documentation.
-    pub(crate) fn resize_runs<F: FormattableText>(&mut self, text: &F, mut dpem: f32) {
+    pub(crate) fn resize_runs<F: FormattableText + ?Sized>(&mut self, text: &F, mut dpem: f32) {
         assert!(self.action <= Action::Resize);
         self.action = Action::Wrap;
 
@@ -86,7 +86,7 @@ impl TextDisplay {
     /// are resized; afterwards, action is no greater than [`Action::Wrap`].
     ///
     /// Parameters: see [`crate::Environment`] documentation.
-    pub fn prepare_runs<F: FormattableText>(
+    pub fn prepare_runs<F: FormattableText + ?Sized>(
         &mut self,
         text: &F,
         direction: Direction,

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -123,7 +123,6 @@ impl TextDisplay {
         let fonts = fonts();
         let mut last_face_id = fonts.first_face_for(font_id);
 
-        let bidi = bidi;
         let default_para_level = match dir {
             Direction::Auto => None,
             Direction::LR => Some(LTR_LEVEL),

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -89,8 +89,7 @@ impl TextDisplay {
     pub fn prepare_runs<F: FormattableText>(
         &mut self,
         text: &F,
-        bidi: bool,
-        dir: Direction,
+        direction: Direction,
         mut font_id: FontId,
         mut dpem: f32,
     ) {
@@ -123,10 +122,12 @@ impl TextDisplay {
         let fonts = fonts();
         let mut last_face_id = fonts.first_face_for(font_id);
 
-        let default_para_level = match dir {
-            Direction::Auto => None,
-            Direction::LR => Some(LTR_LEVEL),
-            Direction::RL => Some(RTL_LEVEL),
+        let (bidi, default_para_level) = match direction {
+            Direction::Bidi => (true, None),
+            Direction::BidiRtl => (true, Some(RTL_LEVEL)),
+            Direction::Single => (false, None),
+            Direction::Ltr => (false, Some(LTR_LEVEL)),
+            Direction::Rtl => (false, Some(RTL_LEVEL)),
         };
         let mut levels = vec![];
         let mut level: Level;

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -5,6 +5,8 @@
 
 //! Text preparation: line breaking and BIDI
 
+#![allow(clippy::unnecessary_unwrap)]
+
 use super::TextDisplay;
 use crate::conv::{to_u32, to_usize};
 use crate::fonts::{fonts, FontId};

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -96,7 +96,7 @@ impl TextDisplay {
         mut dpem: f32,
     ) {
         match self.action {
-            Action::None | Action::Wrap => return,
+            Action::None | Action::VAlign | Action::Wrap => return,
             Action::Resize => return self.resize_runs(text, dpem),
             Action::All => (),
         }

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -384,10 +384,8 @@ impl LineAdder {
                             parts[s..i].reverse();
                             start = None;
                         }
-                    } else {
-                        if part_level >= level {
-                            start = Some(i);
-                        }
+                    } else if part_level >= level {
+                        start = Some(i);
                     }
                 }
                 if let Some(s) = start {
@@ -484,7 +482,7 @@ impl LineAdder {
             self.runs.push(RunPart {
                 text_end,
                 glyph_run: part.run,
-                glyph_range: part.glyph_range.into(),
+                glyph_range: part.glyph_range,
                 offset: Vec2(xoffset, self.vcaret),
             });
             if part.end_space {

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -60,7 +60,6 @@ impl TextDisplay {
         self.action = Action::None;
 
         let wrap = flags.contains(EnvFlags::WRAP);
-        let px_valign = flags.contains(EnvFlags::PX_VALIGN);
 
         let fonts = fonts();
         let capacity = 0; // TODO(opt): estimate like self.text_len() / 16 ?
@@ -121,7 +120,7 @@ impl TextDisplay {
                     if wrap && line_len > width_bound && end.2 > 0 {
                         // Add up to last valid break point then wrap and reset
                         let slice = &mut parts[0..end.2];
-                        adder.add_line(fonts, level, &self.runs, slice, true, px_valign);
+                        adder.add_line(fonts, level, &self.runs, slice, true);
 
                         end.2 = 0;
                         start = end;
@@ -178,7 +177,7 @@ impl TextDisplay {
             if parts.len() > 0 {
                 // It should not be possible for a line to end with a no-break, so:
                 debug_assert_eq!(parts.len(), end.2);
-                adder.add_line(fonts, level, &self.runs, &mut parts, false, px_valign);
+                adder.add_line(fonts, level, &self.runs, &mut parts, false);
             }
         }
 
@@ -220,7 +219,6 @@ impl LineAdder {
         runs: &[GlyphRun],
         parts: &mut [PartInfo],
         is_wrap: bool,
-        px_valign: bool,
     ) {
         assert!(parts.len() > 0);
         let line_start = self.runs.len();
@@ -467,9 +465,9 @@ impl LineAdder {
 
         let top = self.vcaret - ascent;
         self.vcaret -= descent;
-        if px_valign {
-            self.vcaret = self.vcaret.round();
-        }
+        // Vertically align lines to the nearest pixel (improves rendering):
+        self.vcaret = self.vcaret.round();
+
         self.longest = self.longest.max(line_len);
         self.lines.push(Line {
             text_range: Range::from(line_text_start..line_text_end),

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -240,6 +240,7 @@ impl TextDisplay {
         if self.action > Action::VAlign {
             return Err(NotReady);
         }
+        self.action = Action::None;
 
         if self.lines.is_empty() {
             return Ok(Vec2(0.0, 0.0));

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -46,7 +46,7 @@ impl TextDisplay {
     /// than [`Self::prepare_lines`].
     ///
     /// The return value is at most `limit`.
-    pub fn max_line_length(&self, limit: f32) -> Result<f32, NotReady> {
+    pub fn measure_width(&self, limit: f32) -> Result<f32, NotReady> {
         if self.action > Action::Wrap {
             return Err(NotReady);
         }

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -231,6 +231,42 @@ impl TextDisplay {
         self.width = bounds.0;
         Ok(required)
     }
+
+    /// Vertically align lines
+    ///
+    /// Returns the bottom of bounding box after alignment.
+    pub fn vertically_align(&mut self, bound: f32, v_align: Align) -> Result<f32, NotReady> {
+        if self.action > Action::VAlign {
+            return Err(NotReady);
+        }
+
+        if self.lines.is_empty() {
+            return Ok(0.0);
+        }
+
+        let top = self.lines.first().unwrap().top;
+        let bottom = self.lines.last().unwrap().bottom;
+        let height = bottom - top;
+        let new_offset = match v_align {
+            _ if height >= bound => 0.0,
+            Align::Default | Align::TL | Align::Stretch => 0.0,
+            Align::Center => 0.5 * (bound - height),
+            Align::BR => bound - height,
+        };
+        let offset = new_offset - top;
+
+        if offset != 0.0 {
+            for run in &mut self.wrapped_runs {
+                run.offset.1 += offset;
+            }
+            for line in &mut self.lines {
+                line.top += offset;
+                line.bottom += offset;
+            }
+        }
+
+        Ok(bottom)
+    }
 }
 
 #[derive(Default)]

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -9,7 +9,7 @@ use super::{NotReady, RunSpecial, TextDisplay};
 use crate::conv::{to_u32, to_usize};
 use crate::fonts::{fonts, FontLibrary};
 use crate::shaper::GlyphRun;
-use crate::{Action, Align, EnvFlags, Range, Vec2};
+use crate::{Action, Align, Range, Vec2};
 use smallvec::SmallVec;
 use unicode_bidi::Level;
 
@@ -96,15 +96,13 @@ impl TextDisplay {
     pub fn prepare_lines(
         &mut self,
         bounds: Vec2,
-        flags: EnvFlags,
+        wrap: bool,
         align: (Align, Align),
     ) -> Result<Vec2, NotReady> {
         if self.action > Action::Wrap {
             return Err(NotReady);
         }
         self.action = Action::None;
-
-        let wrap = flags.contains(EnvFlags::WRAP);
 
         let fonts = fonts();
         let capacity = 0; // TODO(opt): estimate like self.text_len() / 16 ?

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -45,7 +45,8 @@ impl TextDisplay {
     /// This is a significantly faster way to calculate the required line length
     /// than [`Self::prepare_lines`].
     ///
-    /// The return value is at most `limit`.
+    /// The return value is at most `limit` and is unaffected by alignment and
+    /// wrap configuration of [`crate::Environment`].
     pub fn measure_width(&self, limit: f32) -> Result<f32, NotReady> {
         if self.action > Action::Wrap {
             return Err(NotReady);

--- a/src/env.rs
+++ b/src/env.rs
@@ -69,6 +69,15 @@ impl Default for Environment {
 }
 
 impl Environment {
+    /// Set font size
+    ///
+    /// This is an alternative to setting [`Self::dpem`] directly. It is assumed
+    /// that 72 Points = 1 Inch and the base screen resolution is 96 DPI.
+    /// (Note: MacOS uses a different definition where 1 Point = 1 Pixel.)
+    pub fn set_font_size(&mut self, pt_size: f32, scale_factor: f32) {
+        self.dpem = pt_size * scale_factor * (96.0 / 72.0);
+    }
+
     /// Returns the height of horizontal text
     ///
     /// This should be similar to the value of [`Self::dpem`], but depends on

--- a/src/env.rs
+++ b/src/env.rs
@@ -28,7 +28,7 @@ pub struct Environment {
     /// Alignment (`horiz`, `vert`)
     ///
     /// By default, horizontal alignment is left or right depending on the
-    /// text direction (see [`Environment::dir`]), and vertical alignment is
+    /// text direction (see [`Self::direction`]), and vertical alignment is
     /// to the top.
     pub align: (Align, Align),
     /// Default font

--- a/src/env.rs
+++ b/src/env.rs
@@ -13,20 +13,18 @@ use crate::{Action, Vec2};
 /// An `Environment` can be default-constructed (without line-wrapping).
 #[derive(Clone, Debug, PartialEq)]
 pub struct Environment {
-    /// Flags enabling/disabling certain features
-    ///
-    /// ## Line wrapping
-    ///
-    /// By default, this is true and long text lines are wrapped based on the
-    /// width bounds. If set to false, lines are not wrapped at the width
-    /// boundary, but explicit line-breaks such as `\n` still result in new
-    /// lines.
-    pub flags: EnvFlags,
     /// Text direction
     ///
     /// By default, text direction (LTR or RTL) is automatically detected with
     /// full bi-directional text support (Unicode Technical Report #9).
     pub direction: Direction,
+    /// Line wrapping
+    ///
+    /// By default, this is true and long text lines are wrapped based on the
+    /// width bounds. If set to false, lines are not wrapped at the width
+    /// boundary, but explicit line-breaks such as `\n` still result in new
+    /// lines.
+    pub wrap: bool,
     /// Alignment (`horiz`, `vert`)
     ///
     /// By default, horizontal alignment is left or right depending on the
@@ -60,8 +58,8 @@ pub struct Environment {
 impl Default for Environment {
     fn default() -> Self {
         Environment {
-            flags: Default::default(),
             direction: Direction::default(),
+            wrap: true,
             font_id: Default::default(),
             dpem: 11.0 * 96.0 / 72.0,
             bounds: Vec2::INFINITY,
@@ -140,8 +138,8 @@ impl<'a> UpdateEnv<'a> {
 
     /// Enable or disable line-wrapping
     pub fn set_wrap(&mut self, wrap: bool) {
-        if wrap != self.env.flags.contains(EnvFlags::WRAP) {
-            self.env.flags.set(EnvFlags::WRAP, wrap);
+        if wrap != self.env.wrap {
+            self.env.wrap = wrap;
             self.action = self.action.max(Action::Wrap);
         }
     }
@@ -166,25 +164,6 @@ impl Environment {
             dpem,
             ..Default::default()
         }
-    }
-}
-
-bitflags::bitflags! {
-    /// Environment flags
-    ///
-    /// By default, all flags are enabled
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    pub struct EnvFlags: u8 {
-        /// Enable line wrapping
-        ///
-        /// Without this, only explicit line breaks end lines.
-        const WRAP = 1 << 1;
-    }
-}
-
-impl Default for EnvFlags {
-    fn default() -> Self {
-        EnvFlags::all()
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -6,12 +6,12 @@
 //! KAS Rich-Text library — text-display environment
 
 use crate::fonts::{fonts, FontId};
-use crate::{Action, Vec2};
+use crate::Vec2;
 
 /// Environment in which text is prepared for display
 ///
 /// An `Environment` can be default-constructed (without line-wrapping).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Environment {
     /// Text direction
     ///
@@ -77,83 +77,6 @@ impl Environment {
     /// To use "the standard font", use `font_id = Default::default()`.
     pub fn line_height(&self, font_id: FontId) -> f32 {
         fonts().get_first_face(font_id).height(self.dpem)
-    }
-}
-
-/// Helper to modify an environment
-#[derive(Debug)]
-pub struct UpdateEnv<'a> {
-    env: &'a mut Environment,
-    action: Action,
-}
-
-impl<'a> UpdateEnv<'a> {
-    pub(crate) fn new(env: &'a mut Environment) -> Self {
-        let action = Action::None;
-        UpdateEnv { env, action }
-    }
-
-    pub(crate) fn finish(self) -> Action {
-        self.action
-    }
-
-    /// Read access to the environment
-    pub fn env(&self) -> &Environment {
-        self.env
-    }
-
-    /// Set font
-    pub fn set_font_id(&mut self, font_id: FontId) {
-        if font_id != self.env.font_id {
-            self.env.font_id = font_id;
-            self.action = Action::All;
-        }
-    }
-
-    /// Set font size (pixels per Em)
-    pub fn set_dpem(&mut self, dpem: f32) {
-        if dpem != self.env.dpem {
-            self.env.dpem = dpem;
-            self.action = Action::Resize;
-        }
-    }
-
-    /// Set the default direction
-    pub fn set_direction(&mut self, direction: Direction) {
-        if direction != self.env.direction {
-            self.env.direction = direction;
-            self.action = Action::All;
-        }
-    }
-
-    /// Set the alignment
-    ///
-    /// Takes `(horiz, vert)` tuple to allow easier parameter passing.
-    pub fn set_align(&mut self, align: (Align, Align)) {
-        if align != self.env.align {
-            self.env.align = align;
-            self.action = self.action.max(Action::Wrap);
-        }
-    }
-
-    /// Enable or disable line-wrapping
-    pub fn set_wrap(&mut self, wrap: bool) {
-        if wrap != self.env.wrap {
-            self.env.wrap = wrap;
-            self.action = self.action.max(Action::Wrap);
-        }
-    }
-
-    /// Set the environment's bounds
-    pub fn set_bounds(&mut self, bounds: Vec2) {
-        if bounds != self.env.bounds {
-            // Note (opt): if we had separate align and wrap actions, then we
-            // would only need to do alignment provided:
-            // self.width_required <= bounds.0.min(self.env.bounds.0)
-            // This may not be worth pursuing however.
-            self.env.bounds = bounds;
-            self.action = self.action.max(Action::Wrap);
-        }
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -191,14 +191,13 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct EnvFlags: u8 {
         /// Enable bidirectional text support
+        ///
+        /// Without this, lines are LTR or RTL only (no bidirectional content).
         const BIDI = 1 << 0;
         /// Enable line wrapping
-        const WRAP = 1 << 1;
-        /// Vertically align to the nearest pixel
         ///
-        /// This is highly recommended to avoid rendering artifacts at small
-        /// pixel sizes. Affect on layout is negligible.
-        const PX_VALIGN = 1 << 2;
+        /// Without this, only explicit line breaks end lines.
+        const WRAP = 1 << 1;
     }
 }
 

--- a/src/fonts/families.rs
+++ b/src/fonts/families.rs
@@ -22,7 +22,7 @@
 //!
 //! Font family ordering indicates usage preference.
 
-pub const DEFAULT_SERIF: &[&'static str] = &[
+pub const DEFAULT_SERIF: &[&str] = &[
     "serif",
     "Palatino Linotype",
     "Palatino",
@@ -36,7 +36,7 @@ pub const DEFAULT_SERIF: &[&'static str] = &[
     "Liberation Serif",
 ];
 
-pub const DEFAULT_SANS_SERIF: &[&'static str] = &[
+pub const DEFAULT_SANS_SERIF: &[&str] = &[
     "sans-serif",
     "Tahoma",
     "Noto Sans",
@@ -54,7 +54,7 @@ pub const DEFAULT_SANS_SERIF: &[&'static str] = &[
     "Lucida Sans Unicode",
 ];
 
-pub const DEFAULT_MONOSPACE: &[&'static str] = &[
+pub const DEFAULT_MONOSPACE: &[&str] = &[
     "monospace",
     "Consolas",
     "Droid Sans Mono",
@@ -75,7 +75,7 @@ pub const DEFAULT_MONOSPACE: &[&'static str] = &[
     "Courier",
 ];
 
-pub const DEFAULT_CURSIVE: &[&'static str] = &[
+pub const DEFAULT_CURSIVE: &[&str] = &[
     "cursive",
     "Gabriola",
     "Segoe Script",
@@ -83,7 +83,7 @@ pub const DEFAULT_CURSIVE: &[&'static str] = &[
     "Comic Sans MS",
 ];
 
-pub const DEFAULT_FANTASY: &[&'static str] = &[
+pub const DEFAULT_FANTASY: &[&str] = &[
     "fantasy",
     "Segoe Print",
     "Impact",

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -5,6 +5,8 @@
 
 //! Font library
 
+#![allow(clippy::len_without_is_empty)]
+
 use super::{selector::Database, FaceRef, FontSelector};
 use crate::conv::{to_u32, to_usize};
 use std::collections::hash_map::{Entry, HashMap};
@@ -25,7 +27,7 @@ enum FontError {
     UnitsPerEm,
     #[cfg(feature = "ab_glyph")]
     #[error("font load error")]
-    AbGlyphFontError(#[from] ab_glyph::InvalidFont),
+    AbGlyph(#[from] ab_glyph::InvalidFont),
     #[cfg(feature = "fontdue")]
     #[error("font load error")]
     StrError(&'static str),

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -403,8 +403,8 @@ impl FontLibrary {
     /// [`FaceId`] values are indices assigned consecutively and are permanent.
     /// For any `x < self.num_faces()`, `FaceId(x)` is a valid font face identifier.
     ///
-    /// Font faces may be loaded on demand (by [`crate::Text::prepare`] but are
-    /// never unloaded or adjusted, hence this value may increase but not decrease.
+    /// This value may increase as fonts may be loaded on demand. It will not
+    /// decrease since fonts are never unloaded during program execution.
     pub fn num_faces(&self) -> usize {
         let faces = self.faces.read().unwrap();
         faces.faces.len()

--- a/src/format.rs
+++ b/src/format.rs
@@ -50,22 +50,22 @@ pub trait FormattableText: std::fmt::Debug {
     /// It is expected that [`FontToken::start`] of yielded items is strictly
     /// increasing; if not, formatting may not be applied correctly.
     ///
-    /// The `dpp` and `pt_size` parameters are as in [`crate::Environment`].
+    /// The `dpem` parameter is font size as in [`crate::Environment`].
     ///
     /// For plain text this iterator will be empty.
     #[cfg(feature = "gat")]
-    fn font_tokens<'a>(&'a self, dpp: f32, pt_size: f32) -> Self::FontTokenIter<'a>;
+    fn font_tokens<'a>(&'a self, dpem: f32) -> Self::FontTokenIter<'a>;
 
     /// Construct an iterator over formatting items
     ///
     /// It is expected that [`FontToken::start`] of yielded items is strictly
     /// increasing; if not, formatting may not be applied correctly.
     ///
-    /// The `dpp` and `pt_size` parameters are as in [`crate::Environment`].
+    /// The `dpem` parameter is font size as in [`crate::Environment`].
     ///
     /// For plain text this iterator will be empty.
     #[cfg(not(feature = "gat"))]
-    fn font_tokens(&self, dpp: f32, pt_size: f32) -> OwningVecIter<FontToken>;
+    fn font_tokens(&self, dpem: f32) -> OwningVecIter<FontToken>;
 
     /// Get the sequence of effect tokens
     ///
@@ -101,10 +101,10 @@ pub trait FormattableTextDyn: std::fmt::Debug {
     /// It is expected that [`FontToken::start`] of yielded items is strictly
     /// increasing; if not, formatting may not be applied correctly.
     ///
-    /// The `dpp` and `pt_size` parameters are as in [`crate::Environment`].
+    /// The `dpem` parameter is font size as in [`crate::Environment`].
     ///
     /// For plain text this iterator will be empty.
-    fn font_tokens(&self, dpp: f32, pt_size: f32) -> OwningVecIter<FontToken>;
+    fn font_tokens(&self, dpem: f32) -> OwningVecIter<FontToken>;
 
     /// Get the sequence of effect tokens
     ///
@@ -130,8 +130,8 @@ impl<F: FormattableText + Clone + 'static> FormattableTextDyn for F {
         FormattableText::as_str(self)
     }
 
-    fn font_tokens(&self, dpp: f32, pt_size: f32) -> OwningVecIter<FontToken> {
-        let iter = FormattableText::font_tokens(self, dpp, pt_size);
+    fn font_tokens(&self, dpem: f32) -> OwningVecIter<FontToken> {
+        let iter = FormattableText::font_tokens(self, dpem);
         #[cfg(feature = "gat")]
         {
             OwningVecIter::new(iter.collect())
@@ -165,8 +165,8 @@ impl<'t> FormattableText for &'t dyn FormattableTextDyn {
     }
 
     #[inline]
-    fn font_tokens(&self, dpp: f32, pt_size: f32) -> OwningVecIter<FontToken> {
-        FormattableTextDyn::font_tokens(*self, dpp, pt_size)
+    fn font_tokens(&self, dpem: f32) -> OwningVecIter<FontToken> {
+        FormattableTextDyn::font_tokens(*self, dpem)
     }
 
     fn effect_tokens(&self) -> &[Effect<()>] {

--- a/src/format/markdown.rs
+++ b/src/format/markdown.rs
@@ -117,13 +117,13 @@ impl FormattableText for Markdown {
 
     #[cfg(feature = "gat")]
     #[inline]
-    fn font_tokens<'a>(&'a self, dpp: f32, pt_size: f32) -> Self::FontTokenIter<'a> {
-        FontTokenIter::new(&self.fmt, dpp * pt_size)
+    fn font_tokens<'a>(&'a self, dpem: f32) -> Self::FontTokenIter<'a> {
+        FontTokenIter::new(&self.fmt, dpem)
     }
     #[cfg(not(feature = "gat"))]
     #[inline]
-    fn font_tokens(&self, dpp: f32, pt_size: f32) -> OwningVecIter<FontToken> {
-        let iter = FontTokenIter::new(&self.fmt, dpp * pt_size);
+    fn font_tokens(&self, dpem: f32) -> OwningVecIter<FontToken> {
+        let iter = FontTokenIter::new(&self.fmt, dpem);
         OwningVecIter::new(iter.collect())
     }
 

--- a/src/format/plain.rs
+++ b/src/format/plain.rs
@@ -22,11 +22,11 @@ impl<'t> FormattableText for &'t str {
     }
 
     #[cfg(feature = "gat")]
-    fn font_tokens<'a>(&'a self, _: f32, _: f32) -> Self::FontTokenIter<'a> {
+    fn font_tokens<'a>(&'a self, _: f32) -> Self::FontTokenIter<'a> {
         std::iter::empty()
     }
     #[cfg(not(feature = "gat"))]
-    fn font_tokens(&self, _: f32, _: f32) -> OwningVecIter<FontToken> {
+    fn font_tokens(&self, _: f32) -> OwningVecIter<FontToken> {
         OwningVecIter::new(Vec::new())
     }
 
@@ -44,11 +44,11 @@ impl FormattableText for String {
     }
 
     #[cfg(feature = "gat")]
-    fn font_tokens<'a>(&'a self, _: f32, _: f32) -> Self::FontTokenIter<'a> {
+    fn font_tokens<'a>(&'a self, _: f32) -> Self::FontTokenIter<'a> {
         std::iter::empty()
     }
     #[cfg(not(feature = "gat"))]
-    fn font_tokens(&self, _: f32, _: f32) -> OwningVecIter<FontToken> {
+    fn font_tokens(&self, _: f32) -> OwningVecIter<FontToken> {
         OwningVecIter::new(Vec::new())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::unit_arg)]
 #![allow(clippy::needless_lifetimes)]
+#![allow(clippy::neg_cmp_op_on_partial_ord)]
 
 mod env;
 pub use env::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,10 @@
 
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(feature = "gat", feature(generic_associated_types))]
+#![allow(clippy::len_zero)]
+#![allow(clippy::type_complexity)]
+#![allow(clippy::unit_arg)]
+#![allow(clippy::needless_lifetimes)]
 
 mod env;
 pub use env::*;

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -119,7 +119,7 @@ impl Default for Config {
 }
 
 /// A rastered sprite
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Sprite {
     /// Offset to be added to the glyph position
     pub offset: (i32, i32),

--- a/src/text.rs
+++ b/src/text.rs
@@ -219,8 +219,7 @@ impl<T: FormattableText> TextApi for Text<T> {
             self.env.flags.contains(EnvFlags::BIDI),
             self.env.dir,
             self.env.font_id,
-            self.env.dpp,
-            self.env.pt_size,
+            self.env.dpem,
         );
     }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -11,7 +11,7 @@ use crate::display::{Effect, MarkerPosIter, NotReady, TextDisplay};
 use crate::fonts::FaceId;
 use crate::format::{EditableText, FormattableText};
 use crate::{Action, Glyph, Vec2};
-use crate::{EnvFlags, Environment, UpdateEnv};
+use crate::{Environment, UpdateEnv};
 
 /// Text, prepared for display in a given environment
 ///
@@ -20,48 +20,32 @@ use crate::{EnvFlags, Environment, UpdateEnv};
 ///
 /// Most Functionality is implemented via the [`TextApi`] and [`TextApiExt`]
 /// traits.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Text<T: FormattableText> {
     env: Environment,
     text: T,
     display: TextDisplay,
 }
 
-impl<T: FormattableText + Default> Default for Text<T> {
-    fn default() -> Self {
-        Text::new(Environment::default(), T::default())
-    }
-}
-
 impl<T: FormattableText> Text<T> {
-    /// Construct from an environment and a text model
+    /// Construct from a text model
     ///
     /// This struct must be made ready for usage by calling [`Text::prepare`].
-    pub fn new(env: Environment, text: T) -> Self {
+    #[inline]
+    pub fn new(text: T) -> Self {
+        Text::new_env(Default::default(), text)
+    }
+
+    /// Construct from a text model and environment
+    ///
+    /// This struct must be made ready for usage by calling [`Text::prepare`].
+    #[inline]
+    pub fn new_env(env: Environment, text: T) -> Self {
         Text {
             env,
-            text: text,
-            display: TextDisplay::default(),
+            text,
+            display: Default::default(),
         }
-    }
-
-    /// Construct from a default environment (single-line) and text
-    ///
-    /// The environment is default-constructed, with line-wrapping
-    /// turned off (see [`Environment::flags`] doc).
-    #[inline]
-    pub fn new_single(text: T) -> Self {
-        let mut env = Environment::default();
-        env.flags.remove(EnvFlags::WRAP);
-        Self::new(env, text)
-    }
-
-    /// Construct from a default environment (multi-line) and text
-    ///
-    /// The environment is default-constructed (line-wrap on).
-    #[inline]
-    pub fn new_multi(text: T) -> Self {
-        Self::new(Environment::default(), text)
     }
 
     /// Clone the formatted text

--- a/src/text.rs
+++ b/src/text.rs
@@ -290,17 +290,9 @@ pub trait TextApiExt: TextApi {
 
     /// Get the directionality of the current line
     ///
-    /// Wraps [`TextDisplay::line_is_ltr`].
-    #[inline]
-    fn line_is_ltr(&self, line: usize) -> Result<bool, NotReady> {
-        self.display().line_is_ltr(line)
-    }
-
-    /// Get the directionality of the current line
-    ///
     /// Wraps [`TextDisplay::line_is_rtl`].
     #[inline]
-    fn line_is_rtl(&self, line: usize) -> Result<bool, NotReady> {
+    fn line_is_rtl(&self, line: usize) -> Result<Option<bool>, NotReady> {
         self.display().line_is_rtl(line)
     }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -213,7 +213,7 @@ impl<T: FormattableText> TextApi for Text<T> {
         self.prepare_runs();
 
         self.display
-            .prepare_lines(self.env.bounds, self.env.flags, self.env.align)
+            .prepare_lines(self.env.bounds, self.env.wrap, self.env.align)
             .unwrap()
     }
 
@@ -223,7 +223,7 @@ impl<T: FormattableText> TextApi for Text<T> {
 
         if self.display.required_action() > Action::None {
             self.display
-                .prepare_lines(self.env.bounds, self.env.flags, self.env.align)
+                .prepare_lines(self.env.bounds, self.env.wrap, self.env.align)
                 .ok()
         } else {
             None

--- a/src/text.rs
+++ b/src/text.rs
@@ -21,10 +21,10 @@ use crate::{Direction, Environment};
 /// Most Functionality is implemented via the [`TextApi`] and [`TextApiExt`]
 /// traits.
 #[derive(Clone, Debug, Default)]
-pub struct Text<T: FormattableText> {
+pub struct Text<T: FormattableText + ?Sized> {
     env: Environment,
-    text: T,
     display: TextDisplay,
+    text: T,
 }
 
 impl<T: FormattableText> Text<T> {
@@ -168,7 +168,7 @@ pub trait TextApi {
     fn effect_tokens(&self) -> &[Effect<()>];
 }
 
-impl<T: FormattableText> TextApi for Text<T> {
+impl<T: FormattableText + ?Sized> TextApi for Text<T> {
     #[inline]
     fn display(&self) -> &TextDisplay {
         &self.display
@@ -436,7 +436,7 @@ pub trait EditableTextApi {
     fn swap_string(&mut self, string: &mut String);
 }
 
-impl<T: EditableText> EditableTextApi for Text<T> {
+impl<T: EditableText + ?Sized> EditableTextApi for Text<T> {
     #[inline]
     fn insert_char(&mut self, index: usize, c: char) {
         self.text.insert_char(index, c);
@@ -462,13 +462,13 @@ impl<T: EditableText> EditableTextApi for Text<T> {
     }
 }
 
-impl<T: FormattableText> AsRef<TextDisplay> for Text<T> {
+impl<T: FormattableText + ?Sized> AsRef<TextDisplay> for Text<T> {
     fn as_ref(&self) -> &TextDisplay {
         &self.display
     }
 }
 
-impl<T: FormattableText> AsMut<TextDisplay> for Text<T> {
+impl<T: FormattableText + ?Sized> AsMut<TextDisplay> for Text<T> {
     fn as_mut(&mut self) -> &mut TextDisplay {
         &mut self.display
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -138,6 +138,11 @@ pub trait TextApi {
     /// prepare text for display.
     fn measure_width(&mut self, limit: f32) -> f32;
 
+    /// Measure required vertical height, wrapping as configured
+    ///
+    /// This fully prepares text for display.
+    fn measure_height(&mut self) -> f32;
+
     /// Prepare lines ("wrap")
     ///
     /// Prepares text, returning required size, in pixels.
@@ -240,6 +245,27 @@ impl<T: FormattableText + ?Sized> TextApi for Text<T> {
         }
 
         self.display.measure_width(limit).unwrap()
+    }
+
+    fn measure_height(&mut self) -> f32 {
+        let action = self.display.required_action();
+        if action > Action::Wrap {
+            self.prepare_runs();
+        }
+
+        if action >= Action::Wrap {
+            let result = self
+                .display
+                .prepare_lines(self.env.bounds, self.env.wrap, self.env.align)
+                .unwrap();
+            result.1
+        } else if action == Action::VAlign {
+            self.display
+                .vertically_align(self.env.bounds.1, self.env.align.1)
+                .unwrap()
+        } else {
+            self.display.height().unwrap()
+        }
     }
 
     #[inline]

--- a/src/text.rs
+++ b/src/text.rs
@@ -132,6 +132,12 @@ pub trait TextApi {
     /// environment state.
     fn prepare_runs(&mut self);
 
+    /// Measure required width, up to some `limit`
+    ///
+    /// This calls [`Self::prepare_runs`] where necessary, but does not fully
+    /// prepare text for display.
+    fn measure_width(&mut self, limit: f32) -> f32;
+
     /// Prepare lines ("wrap")
     ///
     /// Prepares text, returning required size, in pixels.
@@ -228,6 +234,14 @@ impl<T: FormattableText + ?Sized> TextApi for Text<T> {
         );
     }
 
+    fn measure_width(&mut self, limit: f32) -> f32 {
+        if self.display.required_action() > Action::Wrap {
+            self.prepare_runs();
+        }
+
+        self.display.measure_width(limit).unwrap()
+    }
+
     #[inline]
     fn prepare_lines(&mut self) -> Vec2 {
         self.prepare_runs();
@@ -264,7 +278,7 @@ impl<T: FormattableText + ?Sized> TextApi for Text<T> {
 
 /// Extension trait over [`TextApi`]
 pub trait TextApiExt: TextApi {
-    /// Update the environment and prepare, returning required size
+    /// Update the environment and do full preparation
     ///
     /// This prepares text as necessary. It always performs line-wrapping.
     fn update_env(&mut self, env: Environment) -> Option<Vec2> {

--- a/src/text.rs
+++ b/src/text.rs
@@ -145,7 +145,7 @@ pub trait TextApi {
 
     /// Prepare lines ("wrap")
     ///
-    /// Prepares text, returning required size, in pixels.
+    /// Prepares text, returning bottom-right corner of bounding box on output.
     ///
     /// This differs slightly from [`TextDisplay::prepare_lines`] in that it does all preparation
     /// necessary. It differs from [`Self::prepare`] in that this method always (re)calculates
@@ -161,7 +161,7 @@ pub trait TextApi {
     /// notice changes in the environment. In case the environment has changed
     /// one should either call [`TextDisplay::require_action`] before this method.
     ///
-    /// Returns new size requirements
+    /// Returns bottom-right corner of bounding box on output
     /// when an update action (other than vertical alignment) occurred.
     /// Returns `None` if no significant action was required
     /// (since requirements are computed as a
@@ -264,7 +264,7 @@ impl<T: FormattableText + ?Sized> TextApi for Text<T> {
                 .vertically_align(self.env.bounds.1, self.env.align.1)
                 .unwrap()
         } else {
-            self.display.height().unwrap()
+            self.display.bounding_box().unwrap().1
         }
     }
 
@@ -306,10 +306,18 @@ impl<T: FormattableText + ?Sized> TextApi for Text<T> {
 pub trait TextApiExt: TextApi {
     /// Update the environment and do full preparation
     ///
+    /// Returns the bottom-right corner of bounding box on output.
+    ///
     /// This prepares text as necessary. It always performs line-wrapping.
     fn update_env(&mut self, env: Environment) -> Option<Vec2> {
         self.set_env(env);
         self.prepare()
+    }
+
+    /// Get the size of the required bounding box
+    fn bounding_box(&mut self) -> Vec2 {
+        self.prepare();
+        self.display().bounding_box().unwrap()
     }
 
     /// Get required action

--- a/src/text.rs
+++ b/src/text.rs
@@ -288,6 +288,14 @@ pub trait TextApiExt: TextApi {
         self.display().line_range(line)
     }
 
+    /// Get the directionality of the first line
+    fn text_is_rtl(&self) -> Result<bool, NotReady> {
+        Ok(match self.display().line_is_rtl(0)? {
+            None => self.env().dir == crate::Direction::RL,
+            Some(is_rtl) => is_rtl,
+        })
+    }
+
     /// Get the directionality of the current line
     ///
     /// Wraps [`TextDisplay::line_is_rtl`].

--- a/src/text.rs
+++ b/src/text.rs
@@ -138,7 +138,7 @@ pub trait TextApi {
 
     /// Require an action
     ///
-    /// Wraps [`TextDisplay::require_action`].
+    /// See [`TextDisplay::require_action`].
     fn require_action(&mut self, action: Action);
 
     /// Prepare text for display
@@ -263,9 +263,9 @@ pub trait TextApiExt: TextApi {
         self.display().action
     }
 
-    /// Get the number of lines
+    /// Get the number of lines (after wrapping)
     ///
-    /// Wraps [`TextDisplay::num_lines`].
+    /// See [`TextDisplay::num_lines`].
     #[inline]
     fn num_lines(&self) -> Result<usize, NotReady> {
         self.display().num_lines()
@@ -273,7 +273,7 @@ pub trait TextApiExt: TextApi {
 
     /// Find the line containing text `index`
     ///
-    /// Wraps [`TextDisplay::find_line`].
+    /// See [`TextDisplay::find_line`].
     #[inline]
     fn find_line(&self, index: usize) -> Result<Option<(usize, std::ops::Range<usize>)>, NotReady> {
         self.display().find_line(index)
@@ -281,7 +281,7 @@ pub trait TextApiExt: TextApi {
 
     /// Get the range of a line, by line number
     ///
-    /// Wraps [`TextDisplay::line_range`].
+    /// See [`TextDisplay::line_range`].
     #[inline]
     fn line_range(&self, line: usize) -> Result<Option<std::ops::Range<usize>>, NotReady> {
         self.display().line_range(line)
@@ -297,7 +297,7 @@ pub trait TextApiExt: TextApi {
 
     /// Get the directionality of the current line
     ///
-    /// Wraps [`TextDisplay::line_is_rtl`].
+    /// See [`TextDisplay::line_is_rtl`].
     #[inline]
     fn line_is_rtl(&self, line: usize) -> Result<Option<bool>, NotReady> {
         self.display().line_is_rtl(line)
@@ -305,7 +305,7 @@ pub trait TextApiExt: TextApi {
 
     /// Find the text index for the glyph nearest the given `pos`
     ///
-    /// Wraps [`TextDisplay::text_index_nearest`].
+    /// See [`TextDisplay::text_index_nearest`].
     #[inline]
     fn text_index_nearest(&self, pos: Vec2) -> Result<usize, NotReady> {
         self.display().text_index_nearest(pos)
@@ -313,7 +313,7 @@ pub trait TextApiExt: TextApi {
 
     /// Find the text index nearest horizontal-coordinate `x` on `line`
     ///
-    /// Wraps [`TextDisplay::line_index_nearest`].
+    /// See [`TextDisplay::line_index_nearest`].
     #[inline]
     fn line_index_nearest(&self, line: usize, x: f32) -> Result<Option<usize>, NotReady> {
         self.display().line_index_nearest(line, x)
@@ -321,14 +321,14 @@ pub trait TextApiExt: TextApi {
 
     /// Find the starting position (top-left) of the glyph at the given index
     ///
-    /// Wraps [`TextDisplay::text_glyph_pos`].
+    /// See [`TextDisplay::text_glyph_pos`].
     fn text_glyph_pos(&self, index: usize) -> Result<MarkerPosIter, NotReady> {
         self.display().text_glyph_pos(index)
     }
 
     /// Get the number of glyphs
     ///
-    /// Wraps [`TextDisplay::num_glyphs`].
+    /// See [`TextDisplay::num_glyphs`].
     #[inline]
     fn num_glyphs(&self) -> usize {
         self.display().num_glyphs()
@@ -336,14 +336,14 @@ pub trait TextApiExt: TextApi {
 
     /// Yield a sequence of positioned glyphs
     ///
-    /// Wraps [`TextDisplay::glyphs`].
+    /// See [`TextDisplay::glyphs`].
     fn glyphs<F: FnMut(FaceId, f32, Glyph)>(&self, f: F) -> Result<(), NotReady> {
         self.display().glyphs(f)
     }
 
     /// Like [`TextDisplay::glyphs`] but with added effects
     ///
-    /// Wraps [`TextDisplay::glyphs_with_effects`].
+    /// See [`TextDisplay::glyphs_with_effects`].
     fn glyphs_with_effects<X, F, G>(
         &self,
         effects: &[Effect<X>],
@@ -362,7 +362,7 @@ pub trait TextApiExt: TextApi {
 
     /// Yield a sequence of rectangles to highlight a given range, by lines
     ///
-    /// Wraps [`TextDisplay::highlight_lines`].
+    /// See [`TextDisplay::highlight_lines`].
     fn highlight_lines(
         &self,
         range: std::ops::Range<usize>,
@@ -372,7 +372,7 @@ pub trait TextApiExt: TextApi {
 
     /// Yield a sequence of rectangles to highlight a given range, by runs
     ///
-    /// Wraps [`TextDisplay::highlight_runs`].
+    /// See [`TextDisplay::highlight_runs`].
     #[inline]
     fn highlight_runs(&self, range: std::ops::Range<usize>) -> Result<Vec<(Vec2, Vec2)>, NotReady> {
         self.display().highlight_runs(range)

--- a/src/text.rs
+++ b/src/text.rs
@@ -216,8 +216,7 @@ impl<T: FormattableText> TextApi for Text<T> {
     fn prepare_runs(&mut self) {
         self.display.prepare_runs(
             &self.text,
-            self.env.flags.contains(EnvFlags::BIDI),
-            self.env.dir,
+            self.env.direction,
             self.env.font_id,
             self.env.dpem,
         );
@@ -289,8 +288,9 @@ pub trait TextApiExt: TextApi {
 
     /// Get the directionality of the first line
     fn text_is_rtl(&self) -> Result<bool, NotReady> {
+        use crate::Direction;
         Ok(match self.display().line_is_rtl(0)? {
-            None => self.env().dir == crate::Direction::RL,
+            None => matches!(self.env().direction, Direction::BidiRtl | Direction::Rtl),
             Some(is_rtl) => is_rtl,
         })
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,6 +10,8 @@
 pub enum Action {
     /// Nothing to do
     None,
+    /// Fix vertical alignment
+    VAlign,
     /// Do wrapping and alignment
     Wrap,
     /// Resize text, and above


### PR DESCRIPTION
This contains a few fixes and a few API tweaks.

- Remove `fn line_is_ltr`; add `fn text_is_rtl`
- Replace separate `dpp`, `pt_size` parameters with single `dpem`
- Remove `PX_VALIGN` configuration flag: there is probably no reason to ever turn this off
- Replace `BIDI` flag with more options under `Direction` enum
- Add `measure_width`, `measure_height`, `bounding_box` and `vertically_align` methods to allow more efficient size-deduction followed by alignment
- `prepare*` and `update_env` methods now only return a boolean describing whether the bounding box is exceeded