### PR TITLE
Require generic associated types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        toolchain: [stable]
+        # TODO: use stable once GATs reach stable
+        toolchain: [beta]
         include:
           - os: ubuntu-latest
-            toolchain: "1.58.0"
+            toolchain: "1.65.0"
           - os: ubuntu-latest
             toolchain: beta
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,6 @@ harfbuzz = ["harfbuzz_rs"]
 # Enable Markdown parsing
 markdown = ["pulldown-cmark"]
 
-# Use Generic Associated Types (experimental)
-gat = []
-
 # Serialization is optionally supported for some types:
 # serde
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Non-pure-Rust alternatives include [font-kit](https://crates.io/crates/font-kit)
 and [piet](https://crates.io/crates/piet) among others.
 
 
+MSRV
+---
+
+The Minium Supported Rust Version is 1.65.0.
+
+
 Contributing
 --------
 

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -130,6 +130,9 @@ impl<'a> FaceStore<'a> {
 
 #[derive(Default)]
 struct FaceList {
+    // Safety: unsafe code depends on entries never moving (hence the otherwise
+    // redundant use of Box). See e.g. FontLibrary::get_face().
+    #[allow(clippy::vec_box)]
     faces: Vec<Box<FaceStore<'static>>>,
     // These are vec-maps. Why? Because length should be short.
     path_hash: Vec<(u64, FaceId)>,

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -38,7 +38,7 @@ enum State {
 fn to_uppercase<'a>(c: Cow<'a, str>) -> Cow<'a, str> {
     match c {
         Cow::Borrowed(b) if !b.chars().any(|c| c.is_lowercase()) => Cow::Borrowed(b),
-        c => Cow::Owned(c.to_owned().to_uppercase()),
+        c => Cow::Owned(c.to_uppercase()),
     }
 }
 

--- a/src/format/markdown.rs
+++ b/src/format/markdown.rs
@@ -8,8 +8,6 @@
 use super::{EditableText, FontToken, FormattableText};
 use crate::conv::to_u32;
 use crate::fonts::{self, FontId, FontSelector, Style, Weight};
-#[cfg(not(feature = "gat"))]
-use crate::OwningVecIter;
 use crate::{Effect, EffectFlags};
 use pulldown_cmark::{Event, HeadingLevel, Tag};
 use std::fmt::Write;
@@ -108,7 +106,6 @@ impl<'a> ExactSizeIterator for FontTokenIter<'a> {}
 impl<'a> FusedIterator for FontTokenIter<'a> {}
 
 impl FormattableText for Markdown {
-    #[cfg(feature = "gat")]
     type FontTokenIter<'a> = FontTokenIter<'a>;
 
     #[inline]
@@ -116,16 +113,9 @@ impl FormattableText for Markdown {
         &self.text
     }
 
-    #[cfg(feature = "gat")]
     #[inline]
     fn font_tokens<'a>(&'a self, dpem: f32) -> Self::FontTokenIter<'a> {
         FontTokenIter::new(&self.fmt, dpem)
-    }
-    #[cfg(not(feature = "gat"))]
-    #[inline]
-    fn font_tokens(&self, dpem: f32) -> OwningVecIter<FontToken> {
-        let iter = FontTokenIter::new(&self.fmt, dpem);
-        OwningVecIter::new(iter.collect())
     }
 
     fn effect_tokens(&self) -> &[Effect<()>] {

--- a/src/format/plain.rs
+++ b/src/format/plain.rs
@@ -7,27 +7,18 @@
 
 use super::{EditableText, FontToken, FormattableText};
 use crate::Effect;
-#[cfg(not(feature = "gat"))]
-use crate::OwningVecIter;
 
 impl<'t> FormattableText for &'t str {
-    #[cfg(feature = "gat")]
-    type FontTokenIter<'a>
+    type FontTokenIter<'a> = std::iter::Empty<FontToken>
     where
-        Self: 'a,
-    = std::iter::Empty<FontToken>;
+        Self: 'a;
 
     fn as_str(&self) -> &str {
         self
     }
 
-    #[cfg(feature = "gat")]
     fn font_tokens<'a>(&'a self, _: f32) -> Self::FontTokenIter<'a> {
         std::iter::empty()
-    }
-    #[cfg(not(feature = "gat"))]
-    fn font_tokens(&self, _: f32) -> OwningVecIter<FontToken> {
-        OwningVecIter::new(Vec::new())
     }
 
     fn effect_tokens(&self) -> &[Effect<()>] {
@@ -36,20 +27,14 @@ impl<'t> FormattableText for &'t str {
 }
 
 impl FormattableText for String {
-    #[cfg(feature = "gat")]
     type FontTokenIter<'a> = std::iter::Empty<FontToken>;
 
     fn as_str(&self) -> &str {
         self
     }
 
-    #[cfg(feature = "gat")]
     fn font_tokens<'a>(&'a self, _: f32) -> Self::FontTokenIter<'a> {
         std::iter::empty()
-    }
-    #[cfg(not(feature = "gat"))]
-    fn font_tokens(&self, _: f32) -> OwningVecIter<FontToken> {
-        OwningVecIter::new(Vec::new())
     }
 
     fn effect_tokens(&self) -> &[Effect<()>] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
 //! [`format`]: mod@format
 
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
-#![cfg_attr(feature = "gat", feature(generic_associated_types))]
 #![allow(clippy::len_zero)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::unit_arg)]


### PR DESCRIPTION
This depends on Rust 1.65.0 (assuming the support for GATs currently in Beta reaches stable as expected).