### PR TITLE
Revisions: move status tracking and Env::* to Text, ...

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -36,6 +36,12 @@ impl Vec2 {
     pub fn max(self, other: Self) -> Self {
         Vec2(self.0.max(other.0), self.1.max(other.1))
     }
+
+    /// Whether both components are finite
+    #[inline]
+    pub fn is_finite(self) -> bool {
+        self.0.is_finite() && self.1.is_finite()
+    }
 }
 
 impl std::ops::Add for Vec2 {

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -12,7 +12,7 @@
 
 use super::{Line, TextDisplay};
 use crate::conv::to_usize;
-use crate::fonts::{fonts, FaceId};
+use crate::fonts::{self, FaceId};
 use crate::{Glyph, Vec2};
 
 /// Effect formatting marker
@@ -181,7 +181,7 @@ impl TextDisplay {
             }
 
             let glyph_run = &self.runs[to_usize(run_part.glyph_run)];
-            let sf = fonts()
+            let sf = fonts::library()
                 .get_face(glyph_run.face_id)
                 .scale_by_dpu(glyph_run.dpu);
 
@@ -317,7 +317,7 @@ impl TextDisplay {
         F: FnMut(FaceId, f32, Glyph, usize, X),
         G: FnMut(f32, f32, f32, f32, usize, X),
     {
-        let fonts = fonts();
+        let fonts = fonts::library();
 
         let mut effect_cur = usize::MAX;
         let mut effect_next = 0;
@@ -506,7 +506,7 @@ impl TextDisplay {
         range: std::ops::Range<usize>,
         f: &mut dyn FnMut(Vec2, Vec2),
     ) {
-        let fonts = fonts();
+        let fonts = fonts::library();
 
         let mut a;
 

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -143,7 +143,8 @@ impl ExactSizeIterator for MarkerPosIter {}
 impl TextDisplay {
     /// Find the starting position (top-left) of the glyph at the given index
     ///
-    /// Requires: text is fully prepared for display.
+    /// [Requires status][Self#status-of-preparation]:
+    /// text is fully prepared for display.
     ///
     /// The index should be no greater than the text length. It is not required
     /// to be on a code-point boundary. Returns an iterator over matching
@@ -233,6 +234,8 @@ impl TextDisplay {
 
     /// Get the number of glyphs
     ///
+    /// [Requires status][Self#status-of-preparation]: lines have been wrapped.
+    ///
     /// This method is a simple memory-read.
     #[inline]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "num_glyphs")))]
@@ -243,7 +246,8 @@ impl TextDisplay {
 
     /// Yield a sequence of positioned glyphs
     ///
-    /// Requires: text is fully prepared for display.
+    /// [Requires status][Self#status-of-preparation]:
+    /// text is fully prepared for display.
     ///
     /// Glyphs are yielded in undefined order by a call to `f`. The number of
     /// glyphs yielded will equal [`TextDisplay::num_glyphs`]. The closure `f`
@@ -279,7 +283,8 @@ impl TextDisplay {
 
     /// Like [`TextDisplay::glyphs`] but with added effects
     ///
-    /// Requires: text is fully prepared for display.
+    /// [Requires status][Self#status-of-preparation]:
+    /// text is fully prepared for display.
     ///
     /// If the list `effects` is empty or has first entry with `start > 0`, the
     /// result of `Effect::default(default_aux)` is used. The user payload of
@@ -467,7 +472,8 @@ impl TextDisplay {
 
     /// Yield a sequence of rectangles to highlight a given text range
     ///
-    /// Requires: text is fully prepared for display.
+    /// [Requires status][Self#status-of-preparation]:
+    /// text is fully prepared for display.
     ///
     /// Calls `f(top_left, bottom_right)` for each highlighting rectangle.
     pub fn highlight_range(&self, range: std::ops::Range<usize>, f: &mut dyn FnMut(Vec2, Vec2)) {
@@ -489,7 +495,8 @@ impl TextDisplay {
 
     /// Produce highlighting rectangles within a range of runs
     ///
-    /// Requires: text is fully prepared for display.
+    /// [Requires status][Self#status-of-preparation]:
+    /// text is fully prepared for display.
     ///
     /// Warning: runs are in logical order which does not correspond to display
     /// order. As a result, the order of results (on a line) is not known.

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -159,7 +159,7 @@ impl TextDisplay {
     /// Depending on the use-case, the caller may need to clamp the resulting
     /// position.
     pub fn text_glyph_pos(&self, index: usize) -> Result<MarkerPosIter, NotReady> {
-        if !self.action.is_ready() {
+        if !self.status.is_ready() {
             return Err(NotReady);
         }
 
@@ -264,7 +264,7 @@ impl TextDisplay {
     /// This method has fairly low cost: `O(n)` in the number of glyphs with
     /// low overhead.
     pub fn glyphs<F: FnMut(FaceId, f32, Glyph)>(&self, mut f: F) -> Result<(), NotReady> {
-        if !self.action.is_ready() {
+        if !self.status.is_ready() {
             return Err(NotReady);
         }
 
@@ -317,7 +317,7 @@ impl TextDisplay {
         F: FnMut(FaceId, f32, Glyph, usize, X),
         G: FnMut(f32, f32, f32, f32, usize, X),
     {
-        if !self.action.is_ready() {
+        if !self.status.is_ready() {
             return Err(NotReady);
         }
 
@@ -484,7 +484,7 @@ impl TextDisplay {
         range: std::ops::Range<usize>,
         f: &mut dyn FnMut(Vec2, Vec2),
     ) -> Result<(), NotReady> {
-        if !self.action.is_ready() {
+        if !self.status.is_ready() {
             return Err(NotReady);
         }
 

--- a/src/display/glyph_pos.rs
+++ b/src/display/glyph_pos.rs
@@ -251,7 +251,7 @@ impl TextDisplay {
     ///
     /// This may be used as follows:
     /// ```no_run
-    /// # use kas_text::{Glyph, Text, Environment, TextApi, TextApiExt};
+    /// # use kas_text::{Glyph, Text, TextApi, TextApiExt, Vec2};
     /// # fn draw(_: Vec<(f32, Glyph)>) {}
     /// let mut text = Text::new("Some example text");
     /// text.prepare();

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -232,17 +232,6 @@ impl TextDisplay {
     ///
     /// This does not require that the text is prepared.
     pub fn text_is_rtl(&self, text: &str, direction: Direction) -> bool {
-        let cached_is_rtl = match self.line_is_rtl(0) {
-            Ok(None) => Some(direction == Direction::Rtl),
-            Ok(Some(is_rtl)) => Some(is_rtl),
-            Err(NotReady) => None,
-        };
-
-        #[cfg(not(debug_assertions))]
-        if let Some(cached) = cached_is_rtl {
-            return cached;
-        }
-
         let (is_auto, mut is_rtl) = match direction {
             Direction::Ltr => (false, false),
             Direction::Rtl => (false, true),
@@ -258,9 +247,6 @@ impl TextDisplay {
             }
         }
 
-        if let Some(cached) = cached_is_rtl {
-            debug_assert_eq!(cached, is_rtl);
-        }
         is_rtl
     }
 

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -6,8 +6,7 @@
 //! Text prepared for display
 
 use crate::conv::to_usize;
-use crate::fonts::InvalidFontId;
-use crate::{shaper, Direction, Status, Vec2};
+use crate::{shaper, Direction, Vec2};
 use smallvec::SmallVec;
 
 mod glyph_pos;
@@ -100,7 +99,6 @@ pub struct TextDisplay {
     //
     /// Level runs within the text, in logical order
     runs: SmallVec<[shaper::GlyphRun; 1]>,
-    status: Status,
     /// Contiguous runs, in logical order
     ///
     /// Within a line, runs may not be in visual order due to BIDI reversals.
@@ -127,7 +125,6 @@ impl Default for TextDisplay {
     fn default() -> Self {
         TextDisplay {
             runs: Default::default(),
-            status: Status::New,
             wrapped_runs: Default::default(),
             lines: Default::default(),
             #[cfg(feature = "num_glyphs")]
@@ -139,31 +136,6 @@ impl Default for TextDisplay {
 }
 
 impl TextDisplay {
-    /// Get status of preparation
-    #[inline]
-    pub fn status(&self) -> Status {
-        self.status
-    }
-
-    /// Adjust status to indicate a required action
-    ///
-    /// This is used to notify that some step of preparation may need to be
-    /// repeated. The internally-tracked status is set to the minimum of
-    /// `status` and its previous value.
-    #[inline]
-    pub fn set_max_status(&mut self, status: Status) {
-        self.status = self.status.min(status);
-    }
-
-    /// Configure text
-    ///
-    /// Text objects must be configured before used.
-    #[inline]
-    pub fn configure(&mut self) -> Result<(), InvalidFontId> {
-        self.status = self.status.max(Status::Configured);
-        Ok(())
-    }
-
     /// Get the number of lines (after wrapping)
     ///
     /// Requires: lines have been wrapped.

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -5,10 +5,10 @@
 
 //! Text prepared for display
 
-use smallvec::SmallVec;
-
 use crate::conv::to_usize;
+use crate::fonts::InvalidFontId;
 use crate::{shaper, Action, Direction, Vec2};
+use smallvec::SmallVec;
 
 mod glyph_pos;
 mod text_runs;
@@ -127,7 +127,7 @@ impl Default for TextDisplay {
     fn default() -> Self {
         TextDisplay {
             runs: Default::default(),
-            action: Action::All, // highest value
+            action: Action::Configure, // highest value
             wrapped_runs: Default::default(),
             lines: Default::default(),
             #[cfg(feature = "num_glyphs")]
@@ -153,6 +153,15 @@ impl TextDisplay {
     #[inline]
     pub fn require_action(&mut self, action: Action) {
         self.action = self.action.max(action);
+    }
+
+    /// Configure text
+    ///
+    /// Text objects must be configured before used.
+    #[inline]
+    pub fn configure(&mut self) -> Result<(), InvalidFontId> {
+        self.action = self.action.min(Action::Break);
+        Ok(())
     }
 
     /// Get the number of lines (after wrapping)

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -9,7 +9,7 @@
 
 use super::TextDisplay;
 use crate::conv::{to_u32, to_usize};
-use crate::fonts::{fonts, FontId, InvalidFontId};
+use crate::fonts::{self, FontId, InvalidFontId};
 use crate::format::FormattableText;
 use crate::{shaper, Direction, Range};
 use unicode_bidi::{BidiClass, BidiInfo, LTR_LEVEL, RTL_LEVEL};
@@ -101,7 +101,7 @@ impl TextDisplay {
             }
         }
 
-        let fonts = fonts();
+        let fonts = fonts::library();
         let text = text.as_str();
 
         let default_para_level = match direction {

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -11,7 +11,7 @@ use super::TextDisplay;
 use crate::conv::{to_u32, to_usize};
 use crate::fonts::{fonts, FontId, InvalidFontId};
 use crate::format::FormattableText;
-use crate::{shaper, Direction, Range, Status};
+use crate::{shaper, Direction, Range};
 use unicode_bidi::{BidiClass, BidiInfo, LTR_LEVEL, RTL_LEVEL};
 use xi_unicode::LineBreakIterator;
 
@@ -34,9 +34,6 @@ impl TextDisplay {
     /// This updates the result of [`TextDisplay::prepare_runs`] due to change
     /// in font size.
     pub fn resize_runs<F: FormattableText + ?Sized>(&mut self, text: &F, dpem: f32) {
-        assert_eq!(self.status, Status::ResizeLevelRuns);
-        self.status = Status::LevelRuns;
-
         let mut font_tokens = text.font_tokens(dpem);
         let mut next_fmt = font_tokens.next();
 
@@ -82,8 +79,6 @@ impl TextDisplay {
         mut font_id: FontId,
         mut dpem: f32,
     ) -> Result<(), InvalidFontId> {
-        assert!(self.status >= Status::Configured);
-
         // This method constructs a list of "hard lines" (the initial line and any
         // caused by a hard break), each composed of a list of "level runs" (the
         // result of splitting and reversing according to Unicode TR9 aka
@@ -263,7 +258,6 @@ impl TextDisplay {
             println!("]");
         }
         */
-        self.status = Status::LevelRuns;
         Ok(())
     }
 }

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -34,7 +34,6 @@ impl TextDisplay {
     ///
     /// Prerequisites: prepared runs: requires action is no greater than `Action::Wrap`.
     /// Post-requirements: prepare lines (requires action `Action::Wrap`).  
-    /// Parameters: see [`crate::Environment`] documentation.
     pub fn resize_runs<F: FormattableText + ?Sized>(&mut self, text: &F, dpem: f32) {
         assert_eq!(self.action, Action::Resize);
         self.action = Action::Wrap;
@@ -75,8 +74,6 @@ impl TextDisplay {
     ///
     /// This is the first step of preparation: breaking text into runs according
     /// to font properties, bidi-levels and line-wrap points.
-    ///
-    /// Parameters: see [`crate::Environment`] documentation.
     pub fn prepare_runs<F: FormattableText + ?Sized>(
         &mut self,
         text: &F,

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -82,7 +82,7 @@ impl TextDisplay {
         mut font_id: FontId,
         mut dpem: f32,
     ) -> Result<(), InvalidFontId> {
-        assert_eq!(self.action, Action::All);
+        assert_eq!(self.action, Action::Break);
 
         // This method constructs a list of "hard lines" (the initial line and any
         // caused by a hard break), each composed of a list of "level runs" (the

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -11,7 +11,7 @@ use super::TextDisplay;
 use crate::conv::{to_u32, to_usize};
 use crate::fonts::{fonts, FontId, InvalidFontId};
 use crate::format::FormattableText;
-use crate::{shaper, Action, Direction, Range};
+use crate::{shaper, Direction, Range, Status};
 use unicode_bidi::{BidiClass, BidiInfo, LTR_LEVEL, RTL_LEVEL};
 use xi_unicode::LineBreakIterator;
 
@@ -32,11 +32,11 @@ impl TextDisplay {
     /// This updates the result of [`TextDisplay::prepare_runs`] due to change
     /// in font size.
     ///
-    /// Prerequisites: prepared runs: requires action is no greater than `Action::Wrap`.
-    /// Post-requirements: prepare lines (requires action `Action::Wrap`).  
+    /// Prerequisites: prepared runs: requires status is no less than `Status::LevelRuns`.
+    /// Post-requirements: prepare lines (status is `Status::LevelRuns`).
     pub fn resize_runs<F: FormattableText + ?Sized>(&mut self, text: &F, dpem: f32) {
-        assert_eq!(self.action, Action::Resize);
-        self.action = Action::Wrap;
+        assert_eq!(self.status, Status::ResizeLevelRuns);
+        self.status = Status::LevelRuns;
 
         let mut font_tokens = text.font_tokens(dpem);
         let mut next_fmt = font_tokens.next();
@@ -81,7 +81,7 @@ impl TextDisplay {
         mut font_id: FontId,
         mut dpem: f32,
     ) -> Result<(), InvalidFontId> {
-        assert_eq!(self.action, Action::Break);
+        assert!(self.status >= Status::Configured);
 
         // This method constructs a list of "hard lines" (the initial line and any
         // caused by a hard break), each composed of a list of "level runs" (the
@@ -262,7 +262,7 @@ impl TextDisplay {
             println!("]");
         }
         */
-        self.action = Action::Wrap;
+        self.status = Status::LevelRuns;
         Ok(())
     }
 }

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -29,11 +29,10 @@ pub(crate) enum RunSpecial {
 impl TextDisplay {
     /// Update font size
     ///
+    /// Requires: level runs have been prepared.
+    ///
     /// This updates the result of [`TextDisplay::prepare_runs`] due to change
     /// in font size.
-    ///
-    /// Prerequisites: prepared runs: requires status is no less than `Status::LevelRuns`.
-    /// Post-requirements: prepare lines (status is `Status::LevelRuns`).
     pub fn resize_runs<F: FormattableText + ?Sized>(&mut self, text: &F, dpem: f32) {
         assert_eq!(self.status, Status::ResizeLevelRuns);
         self.status = Status::LevelRuns;
@@ -69,6 +68,8 @@ impl TextDisplay {
     }
 
     /// Prepare text runs
+    ///
+    /// Requires: none.
     ///
     /// Prerequisite: assign to or assert validity of `self.default_font_id`.
     ///

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -29,7 +29,8 @@ pub(crate) enum RunSpecial {
 impl TextDisplay {
     /// Update font size
     ///
-    /// Requires: level runs have been prepared.
+    /// [Requires status][Self#status-of-preparation]: level runs have been
+    /// prepared and are valid in all ways except size (`dpem`).
     ///
     /// This updates the result of [`TextDisplay::prepare_runs`] due to change
     /// in font size.
@@ -64,14 +65,17 @@ impl TextDisplay {
         }
     }
 
-    /// Prepare text runs
+    /// Break text into level runs
     ///
-    /// Requires: none.
+    /// [Requires status][Self#status-of-preparation]: none.
     ///
-    /// Prerequisite: assign to or assert validity of `self.default_font_id`.
+    /// Must be called again if any of `text`, `direction` or `font_id` change.
+    /// If only `dpem` changes, [`Self::resize_runs`] may be called instead.
     ///
-    /// This is the first step of preparation: breaking text into runs according
-    /// to font properties, bidi-levels and line-wrap points.
+    /// The text is broken into a set of contiguous "level runs". These runs are
+    /// maximal slices of the `text` which do not contain explicit line breaks
+    /// and have a single text direction according to the
+    /// [Unicode Bidirectional Algorithm](http://www.unicode.org/reports/tr9/).
     pub fn prepare_runs<F: FormattableText + ?Sized>(
         &mut self,
         text: &F,

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -71,6 +71,8 @@ impl TextDisplay {
 
     /// Prepare text runs
     ///
+    /// Prerequisite: assign to or assert validity of `self.default_font_id`.
+    ///
     /// This is the first step of preparation: breaking text into runs according
     /// to font properties, bidi-levels and line-wrap points.
     ///

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -7,7 +7,7 @@
 
 use super::{RunSpecial, TextDisplay};
 use crate::conv::{to_u32, to_usize};
-use crate::fonts::{fonts, FontLibrary};
+use crate::fonts::{self, FontLibrary};
 use crate::shaper::{GlyphRun, PartMetrics};
 use crate::{Align, Range, Vec2};
 use smallvec::SmallVec;
@@ -178,7 +178,7 @@ impl TextDisplay {
     }
 
     fn wrap_lines(&self, accumulator: &mut impl PartAccumulator, wrap_width: f32) {
-        let fonts = fonts();
+        let fonts = fonts::library();
 
         // Tuples: (index, part_index, num_parts)
         let mut start = (0, 0, 0);

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -32,7 +32,8 @@ pub struct Line {
 impl TextDisplay {
     /// Measure required width, up to some `max_width`
     ///
-    /// Requires: level runs have been prepared.
+    /// [Requires status][Self#status-of-preparation]: level runs have been
+    /// prepared.
     ///
     /// This method allows calculation of the width requirement of a text object
     /// without full wrapping and glyph placement. Whenever the requirement
@@ -68,7 +69,8 @@ impl TextDisplay {
 
     /// Measure required vertical height, wrapping as configured
     ///
-    /// Requires: level runs have been prepared.
+    /// [Requires status][Self#status-of-preparation]: level runs have been
+    /// prepared.
     ///
     /// This method performs most required preparation steps of the
     /// [`TextDisplay`]. Remaining prepartion should be fast.
@@ -152,7 +154,8 @@ impl TextDisplay {
 
     /// Prepare lines ("wrap")
     ///
-    /// Requires: level runs have been prepared.
+    /// [Requires status][Self#status-of-preparation]: level runs have been
+    /// prepared.
     ///
     /// This does text layout, including wrapping and horizontal alignment but
     /// excluding vertical alignment.
@@ -262,7 +265,7 @@ impl TextDisplay {
 
     /// Vertically align lines
     ///
-    /// Requires: lines have been wrapped.
+    /// [Requires status][Self#status-of-preparation]: lines have been wrapped.
     ///
     /// Returns the bottom-right bounding corner.
     pub fn vertically_align(&mut self, bound: f32, v_align: Align) -> Vec2 {

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -9,7 +9,7 @@ use super::{RunSpecial, TextDisplay};
 use crate::conv::{to_u32, to_usize};
 use crate::fonts::{fonts, FontLibrary};
 use crate::shaper::{GlyphRun, PartMetrics};
-use crate::{Align, Range, Status, Vec2};
+use crate::{Align, Range, Vec2};
 use smallvec::SmallVec;
 use unicode_bidi::{Level, LTR_LEVEL};
 
@@ -159,8 +159,6 @@ impl TextDisplay {
     ///
     /// Returns the required height.
     pub fn prepare_lines(&mut self, wrap_width: f32, width_bound: f32, h_align: Align) -> f32 {
-        self.status = Status::Wrapped;
-
         let mut adder = LineAdder::new(width_bound, h_align);
 
         self.wrap_lines(&mut adder, wrap_width);
@@ -269,7 +267,6 @@ impl TextDisplay {
     /// Returns the bottom-right bounding corner.
     pub fn vertically_align(&mut self, bound: f32, v_align: Align) -> Vec2 {
         debug_assert!(bound.is_finite());
-        self.status = Status::Ready;
 
         if self.lines.is_empty() {
             return Vec2(0.0, 0.0);

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -250,6 +250,7 @@ impl TextDisplay {
     ///
     /// Returns the bottom-right bounding corner.
     pub fn vertically_align(&mut self, bound: f32, v_align: Align) -> Result<Vec2, NotReady> {
+        debug_assert!(bound.is_finite());
         if self.action > Action::VAlign {
             return Err(NotReady);
         }

--- a/src/env.rs
+++ b/src/env.rs
@@ -32,11 +32,6 @@ pub struct Environment {
     /// text direction (see [`Self::direction`]), and vertical alignment
     /// is to the top.
     pub align: (Align, Align),
-    /// Default font
-    ///
-    /// This font is used unless a formatting token (see [`crate::format`])
-    /// is used.
-    pub font_id: FontId,
     /// Font size: pixels per Em
     ///
     /// This is a scaling factor used to convert font sizes, with units
@@ -61,7 +56,6 @@ impl Default for Environment {
         Environment {
             direction: Direction::default(),
             wrap: true,
-            font_id: Default::default(),
             dpem: 16.0,
             bounds: Vec2::INFINITY,
             align: Default::default(),
@@ -164,9 +158,4 @@ pub enum Direction {
     ///
     /// This uses Unicode TR9 HL1 to set an explicit paragraph embedding level of 1.
     Rtl = 1,
-}
-
-#[test]
-fn size() {
-    assert_eq!(std::mem::size_of::<Environment>(), 20);
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -12,13 +12,6 @@ use crate::Vec2;
 /// An `Environment` can be default-constructed (without line-wrapping).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Environment {
-    /// Line wrapping
-    ///
-    /// By default, this is true and long text lines are wrapped based on the
-    /// width bounds. If set to false, lines are not wrapped at the width
-    /// boundary, but explicit line-breaks such as `\n` still result in new
-    /// lines.
-    pub wrap: bool,
     /// Alignment (`horiz`, `vert`)
     ///
     /// By default, horizontal alignment is left or right depending on the
@@ -37,7 +30,6 @@ pub struct Environment {
 impl Default for Environment {
     fn default() -> Self {
         Environment {
-            wrap: true,
             bounds: Vec2::INFINITY,
             align: Default::default(),
         }

--- a/src/env.rs
+++ b/src/env.rs
@@ -5,30 +5,6 @@
 
 //! KAS Rich-Text library — text-display environment
 
-use crate::Vec2;
-
-/// Environment in which text is prepared for display
-///
-/// An `Environment` can be default-constructed (without line-wrapping).
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Environment {
-    /// The available (horizontal and vertical) space
-    ///
-    /// This defaults to infinity (implying no bounds). To enable line-wrapping
-    /// set at least a horizontal bound. The vertical bound is required for
-    /// alignment (when aligning to the center or bottom).
-    /// Glyphs outside of these bounds may not be drawn.
-    pub bounds: Vec2,
-}
-
-impl Default for Environment {
-    fn default() -> Self {
-        Environment {
-            bounds: Vec2::INFINITY,
-        }
-    }
-}
-
 /// Alignment of contents
 ///
 /// Note that alignment information is often passed as a `(horiz, vert)` pair.

--- a/src/env.rs
+++ b/src/env.rs
@@ -5,7 +5,6 @@
 
 //! KAS Rich-Text library — text-display environment
 
-use crate::fonts::{fonts, FontId, InvalidFontId};
 use crate::Vec2;
 
 /// Environment in which text is prepared for display
@@ -32,16 +31,6 @@ pub struct Environment {
     /// text direction (see [`Self::direction`]), and vertical alignment
     /// is to the top.
     pub align: (Align, Align),
-    /// Font size: pixels per Em
-    ///
-    /// This is a scaling factor used to convert font sizes, with units
-    /// `pixels/Em`. Equivalently, this is the line-height in pixels.
-    /// See [`crate::fonts`] documentation.
-    ///
-    /// To calculate this from text size in Points, use `dpem = dpp * pt_size`
-    /// where the dots-per-point is usually `dpp = scale_factor * 96.0 / 72.0`
-    /// on PC platforms, or `dpp = 1` on MacOS (or 2 for retina displays).
-    pub dpem: f32,
     /// The available (horizontal and vertical) space
     ///
     /// This defaults to infinity (implying no bounds). To enable line-wrapping
@@ -56,42 +45,8 @@ impl Default for Environment {
         Environment {
             direction: Direction::default(),
             wrap: true,
-            dpem: 16.0,
             bounds: Vec2::INFINITY,
             align: Default::default(),
-        }
-    }
-}
-
-impl Environment {
-    /// Set font size
-    ///
-    /// This is an alternative to setting [`Self::dpem`] directly. It is assumed
-    /// that 72 Points = 1 Inch and the base screen resolution is 96 DPI.
-    /// (Note: MacOS uses a different definition where 1 Point = 1 Pixel.)
-    pub fn set_font_size(&mut self, pt_size: f32, scale_factor: f32) {
-        self.dpem = pt_size * scale_factor * (96.0 / 72.0);
-    }
-
-    /// Returns the height of horizontal text
-    ///
-    /// This should be similar to the value of [`Self::dpem`], but depends on
-    /// the font.
-    ///
-    /// To use "the standard font", use `font_id = Default::default()`.
-    pub fn line_height(&self, font_id: FontId) -> Result<f32, InvalidFontId> {
-        fonts()
-            .get_first_face(font_id)
-            .map(|face| face.height(self.dpem))
-    }
-}
-
-impl Environment {
-    /// Construct, with explicit font size (pixels per Em)
-    pub fn new(dpem: f32) -> Self {
-        Environment {
-            dpem,
-            ..Default::default()
         }
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -12,12 +12,6 @@ use crate::Vec2;
 /// An `Environment` can be default-constructed (without line-wrapping).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Environment {
-    /// Base text direction
-    ///
-    /// Texts may be bi-directional as specified by Unicode Technical Report #9.
-    /// This value controls the base paragraph direction (TR9 HL1).
-    pub direction: Direction,
-
     /// Line wrapping
     ///
     /// By default, this is true and long text lines are wrapped based on the
@@ -43,7 +37,6 @@ pub struct Environment {
 impl Default for Environment {
     fn default() -> Self {
         Environment {
-            direction: Direction::default(),
             wrap: true,
             bounds: Vec2::INFINITY,
             align: Default::default(),

--- a/src/env.rs
+++ b/src/env.rs
@@ -12,12 +12,6 @@ use crate::Vec2;
 /// An `Environment` can be default-constructed (without line-wrapping).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Environment {
-    /// Alignment (`horiz`, `vert`)
-    ///
-    /// By default, horizontal alignment is left or right depending on the
-    /// text direction (see [`Self::direction`]), and vertical alignment
-    /// is to the top.
-    pub align: (Align, Align),
     /// The available (horizontal and vertical) space
     ///
     /// This defaults to infinity (implying no bounds). To enable line-wrapping
@@ -31,7 +25,6 @@ impl Default for Environment {
     fn default() -> Self {
         Environment {
             bounds: Vec2::INFINITY,
-            align: Default::default(),
         }
     }
 }

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -163,7 +163,7 @@ impl FontList {
 
 /// Library of loaded fonts
 ///
-/// This is the type of the global singleton accessible via the [`fonts`]
+/// This is the type of the global singleton accessible via the [`library()`]
 /// function. Thread-safety is handled via internal locks.
 pub struct FontLibrary {
     db: RwLock<Database>,
@@ -543,7 +543,7 @@ lazy_static::lazy_static! {
 }
 
 /// Access the [`FontLibrary`] singleton
-pub fn fonts() -> &'static FontLibrary {
+pub fn library() -> &'static FontLibrary {
     &LIBRARY
 }
 

--- a/src/fonts/mod.rs
+++ b/src/fonts/mod.rs
@@ -6,7 +6,7 @@
 //! Font selection and loading
 //!
 //! Fonts are managed by the [`FontLibrary`], of which a static singleton
-//! exists and can be accessed via [`fonts`].
+//! exists and can be accessed via [`library()`].
 //!
 //! ### `FontId` and the default font
 //!
@@ -16,7 +16,7 @@
 //! To make this work, the user of this library *must* load the default font
 //! before all other fonts and before any operation requiring font metrics:
 //! ```
-//! if let Err(e) = kas_text::fonts::fonts().select_default() {
+//! if let Err(e) = kas_text::fonts::library().select_default() {
 //!     panic!("Error loading font: {}", e);
 //! }
 //! // from now on, kas_text::fonts::FontId::default() identifies the default font
@@ -79,7 +79,7 @@ mod library;
 mod selector;
 
 pub use face::{FaceRef, ScaledFaceRef};
-pub use library::{fonts, FaceData, FaceId, FontId, FontLibrary, InvalidFontId};
+pub use library::{library, FaceData, FaceId, FontId, FontLibrary, InvalidFontId};
 pub use selector::*;
 
 impl From<GlyphId> for ttf_parser::GlyphId {

--- a/src/fonts/selector.rs
+++ b/src/fonts/selector.rs
@@ -44,14 +44,12 @@ fn to_uppercase<'a>(c: Cow<'a, str>) -> Cow<'a, str> {
 
 /// Manages the list of available fonts and font selection
 ///
-/// This database exists as a singleton, accessible through the [`fonts`]
-/// function.
+/// This database exists as a singleton, accessible through
+/// [`crate::fonts::library()`].
 ///
 /// After initialization font loading and alias adjustment is disabled. The
 /// reason for this is that font selection uses multiple caches and
 /// there is no mechanism for forcing fresh lookups everywhere.
-///
-/// [`fonts`]: super::fonts
 pub struct Database {
     state: State,
     db: fontdb::Database,

--- a/src/format.rs
+++ b/src/format.rs
@@ -6,9 +6,9 @@
 //! Parsers for formatted text
 
 use crate::fonts::FontId;
-#[allow(unused)]
-use crate::Text; // for doc-links
 use crate::{Effect, OwningVecIter};
+#[allow(unused)]
+use crate::{Text, TextDisplay}; // for doc-links
 
 mod plain;
 
@@ -42,7 +42,8 @@ pub trait FormattableText: std::fmt::Debug {
     /// It is expected that [`FontToken::start`] of yielded items is strictly
     /// increasing; if not, formatting may not be applied correctly.
     ///
-    /// The `dpem` parameter is font size as in [`crate::Environment`].
+    /// The default [font size][crate::TextApi::set_font_size] (`dpem`) is passed
+    /// as a reference.
     ///
     /// For plain text this iterator will be empty.
     fn font_tokens<'a>(&'a self, dpem: f32) -> Self::FontTokenIter<'a>;
@@ -81,7 +82,8 @@ pub trait FormattableTextDyn: std::fmt::Debug {
     /// It is expected that [`FontToken::start`] of yielded items is strictly
     /// increasing; if not, formatting may not be applied correctly.
     ///
-    /// The `dpem` parameter is font size as in [`crate::Environment`].
+    /// The default [font size][crate::TextApi::set_font_size] (`dpem`) is passed
+    /// as a reference.
     ///
     /// For plain text this iterator will be empty.
     fn font_tokens(&self, dpem: f32) -> OwningVecIter<FontToken>;

--- a/src/format/markdown.rs
+++ b/src/format/markdown.rs
@@ -177,7 +177,7 @@ impl EditableText for Markdown {
 fn parse(input: &str) -> Result<Markdown, Error> {
     let mut text = String::with_capacity(input.len());
     let mut fmt: Vec<Fmt> = Vec::new();
-    let fonts = fonts::fonts();
+    let fonts = fonts::library();
     let mut set_last = |item: &StackItem| {
         let f = Fmt::new(fonts, item);
         if let Some(last) = fmt.last_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod text;
 pub use text::*;
 
 mod util;
-pub use util::{Action, OwningVecIter};
+pub use util::{OwningVecIter, Status};
 
 pub(crate) mod shaper;
 pub use shaper::{Glyph, GlyphId};

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -57,7 +57,7 @@
 //! }
 //! ```
 
-use crate::fonts::{fonts, FaceId};
+use crate::fonts::{self, FaceId};
 use crate::{Glyph, GlyphId};
 use easy_cast::*;
 
@@ -221,7 +221,7 @@ fn raster_ab(config: &Config, desc: SpriteDescriptor) -> Option<Sprite> {
 
     let id = desc.glyph();
     let face = desc.face();
-    let face_store = fonts().get_face_store(face);
+    let face_store = fonts::library().get_face_store(face);
     let dpem = desc.dpem(config);
 
     let (mut x, y) = desc.fractional_position(config);
@@ -260,7 +260,7 @@ fn raster_ab(config: &Config, desc: SpriteDescriptor) -> Option<Sprite> {
 #[cfg(feature = "fontdue")]
 fn raster_fontdue(config: &Config, desc: SpriteDescriptor) -> Option<Sprite> {
     let face = desc.face();
-    let face = &fonts().get_face_store(face).fontdue;
+    let face = &fonts::library().get_face_store(face).fontdue;
 
     let (metrics, data) = face.rasterize_indexed(desc.glyph().0, desc.dpem(config));
 

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -19,7 +19,7 @@
 
 use crate::conv::{to_u32, to_usize, DPU};
 use crate::display::RunSpecial;
-use crate::fonts::{fonts, FaceId};
+use crate::fonts::{self, FaceId};
 use crate::{Range, Vec2};
 use smallvec::SmallVec;
 use unicode_bidi::Level;
@@ -260,7 +260,7 @@ pub(crate) fn shape(
     let mut no_space_end = 0.0;
     let mut caret = 0.0;
 
-    let face = fonts().get_face(face_id);
+    let face = fonts::library().get_face(face_id);
     let dpu = face.dpu(dpem);
     let sf = face.scale_by_dpu(dpu);
 
@@ -330,7 +330,7 @@ fn shape_harfbuzz(
     level: Level,
     breaks: &mut [GlyphBreak],
 ) -> (Vec<Glyph>, f32, f32) {
-    let mut font = fonts().get_harfbuzz(face_id);
+    let mut font = fonts::library().get_harfbuzz(face_id);
 
     // ppem affects hinting but does not scale layout, so this has little effect:
     font.set_ppem(dpem as u32, dpem as u32);
@@ -417,7 +417,7 @@ fn shape_rustybuzz(
     level: Level,
     breaks: &mut [GlyphBreak],
 ) -> (Vec<Glyph>, f32, f32) {
-    let fonts = fonts();
+    let fonts = fonts::library();
     let dpu = fonts.get_face(face_id).dpu(dpem);
     let face = fonts.get_rustybuzz(face_id);
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -26,11 +26,11 @@ use crate::{Align, Direction, Glyph, Status, Vec2};
 /// [state of preparation][TextDisplay#status-of-preparation] and will perform
 /// steps as required. To use this struct:
 /// ```
-/// use kas_text::{fonts::fonts, Text, TextApi, TextApiExt, Vec2};
+/// use kas_text::{fonts, Text, TextApi, TextApiExt, Vec2};
 /// use std::path::Path;
 ///
 /// // Load system fonts and select a default:
-/// let fonts = fonts();
+/// let fonts = fonts::library();
 /// fonts.select_default().expect("failed to select default font");
 ///
 /// let mut text = Text::new("Hello, world!");
@@ -487,7 +487,7 @@ impl<T: FormattableText + ?Sized> TextApi for Text<T> {
     #[inline]
     fn configure(&mut self) -> Result<(), InvalidFontId> {
         // Validate default_font_id
-        let _ = fonts::fonts().first_face_for(self.font_id)?;
+        let _ = fonts::library().first_face_for(self.font_id)?;
 
         self.status = self.status.max(Status::Configured);
         Ok(())
@@ -496,7 +496,7 @@ impl<T: FormattableText + ?Sized> TextApi for Text<T> {
     fn line_height(&self) -> Result<f32, NotReady> {
         self.check_status(Status::Configured)?;
 
-        fonts::fonts()
+        fonts::library()
             .get_first_face(self.get_font())
             .map(|face| face.height(self.get_font_size()))
             .map_err(|_| {

--- a/src/text.rs
+++ b/src/text.rs
@@ -9,7 +9,6 @@ use crate::display::{Effect, MarkerPosIter, NotReady, TextDisplay};
 use crate::fonts::{fonts, FaceId, FontId, InvalidFontId};
 use crate::format::{EditableText, FormattableText};
 use crate::{Align, Direction, Glyph, Status, Vec2};
-use std::ops::{Deref, DerefMut};
 
 /// Text, prepared for display in a given environment
 ///
@@ -741,31 +740,5 @@ impl<T: EditableText + ?Sized> EditableTextApi for Text<T> {
     fn swap_string(&mut self, string: &mut String) {
         self.text.swap_string(string);
         self.set_max_status(Status::Configured);
-    }
-}
-
-impl<T: FormattableText + ?Sized> Deref for Text<T> {
-    type Target = TextDisplay;
-
-    fn deref(&self) -> &TextDisplay {
-        &self.display
-    }
-}
-
-impl<T: FormattableText + ?Sized> DerefMut for Text<T> {
-    fn deref_mut(&mut self) -> &mut TextDisplay {
-        &mut self.display
-    }
-}
-
-impl<T: FormattableText + ?Sized> AsRef<TextDisplay> for Text<T> {
-    fn as_ref(&self) -> &TextDisplay {
-        &self.display
-    }
-}
-
-impl<T: FormattableText + ?Sized> AsMut<TextDisplay> for Text<T> {
-    fn as_mut(&mut self) -> &mut TextDisplay {
-        &mut self.display
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -279,9 +279,6 @@ pub trait TextApi {
     /// Measure required vertical height, wrapping as configured
     ///
     /// [`configure`][Self::configure] must be called before this method.
-    ///
-    /// This method performs most required preparation steps of the
-    /// [`TextDisplay`]. Remaining prepartion should be fast.
     fn measure_height(&mut self) -> Result<f32, NotReady>;
 
     /// Prepare text for display, as necessary
@@ -441,8 +438,7 @@ impl<T: FormattableText + ?Sized> TextApi for Text<T> {
 
     fn measure_height(&mut self) -> Result<f32, NotReady> {
         self.prepare_runs()?;
-        self.display
-            .measure_height(self.env.bounds.0, self.wrap_width, self.align.0)
+        self.display.measure_height(self.wrap_width)
     }
 
     #[inline]
@@ -454,7 +450,7 @@ impl<T: FormattableText + ?Sized> TextApi for Text<T> {
 
         if action == Action::Wrap {
             self.display
-                .prepare_lines(self.env.bounds.0, self.wrap_width, self.align.0)?;
+                .prepare_lines(self.wrap_width, self.env.bounds.0, self.align.0)?;
         }
 
         Ok(if action >= Action::VAlign {

--- a/src/text.rs
+++ b/src/text.rs
@@ -47,10 +47,14 @@ impl<T: FormattableText> Text<T> {
         }
     }
 
-    /// Construct from parts
+    /// Replace the [`TextDisplay`]
+    ///
+    /// This may be used with [`Self::new`] to reconstruct an object which was
+    /// disolved [`into_parts`][Self::into_parts].
     #[inline]
-    pub fn from_parts(env: Environment, display: TextDisplay, text: T) -> Self {
-        Text { env, display, text }
+    pub fn with_display(mut self, display: TextDisplay) -> Self {
+        self.display = display;
+        self
     }
 
     /// Decompose into parts

--- a/src/text.rs
+++ b/src/text.rs
@@ -6,14 +6,42 @@
 //! Text object
 
 use crate::display::{Effect, MarkerPosIter, NotReady, TextDisplay};
-use crate::fonts::{fonts, FaceId, FontId, InvalidFontId};
+use crate::fonts::{self, FaceId, FontId, InvalidFontId};
 use crate::format::{EditableText, FormattableText};
 use crate::{Align, Direction, Glyph, Status, Vec2};
 
-/// Text, prepared for display in a given environment
+/// Text type-setting object (high-level API)
 ///
-/// This struct is composed of two parts: a representation
-/// of the [`FormattableText`] being displayed, and a [`TextDisplay`] object.
+/// This struct contains:
+/// -   A [`FormattableText`]
+/// -   A [`TextDisplay`]
+/// -   Type-setting configuration. Values have reasonable defaults:
+///     -   The default font will be the first loaded font: see [fonts].
+///     -   The default font size is 16px (the web default).
+///     -   Default text direction and alignment is inferred from the text.
+///     -   Line-wrapping requires a call to [`TextApi::set_wrap_width`].
+///     -   The bounds used for alignment [must be set][TextApi::set_bounds].
+///
+/// This struct tracks the [`TextDisplay`]'s
+/// [state of preparation][TextDisplay#status-of-preparation] and will perform
+/// steps as required. To use this struct:
+/// ```
+/// use kas_text::{fonts::fonts, Text, TextApi, TextApiExt, Vec2};
+/// use std::path::Path;
+///
+/// // Load system fonts and select a default:
+/// let fonts = fonts();
+/// fonts.select_default().expect("failed to select default font");
+///
+/// let mut text = Text::new("Hello, world!");
+/// text.configure().unwrap();
+/// text.set_bounds(Vec2(200.0, 50.0));
+/// text.prepare().unwrap();
+///
+/// text.glyphs(|face, dpem, glyph| {
+///     println!("{face:?} - {dpem}px - {glyph:?}");
+/// });
+/// ```
 ///
 /// Most Functionality is implemented via the [`TextApi`] and [`TextApiExt`]
 /// traits.
@@ -459,7 +487,7 @@ impl<T: FormattableText + ?Sized> TextApi for Text<T> {
     #[inline]
     fn configure(&mut self) -> Result<(), InvalidFontId> {
         // Validate default_font_id
-        let _ = fonts().first_face_for(self.font_id)?;
+        let _ = fonts::fonts().first_face_for(self.font_id)?;
 
         self.status = self.status.max(Status::Configured);
         Ok(())
@@ -468,7 +496,7 @@ impl<T: FormattableText + ?Sized> TextApi for Text<T> {
     fn line_height(&self) -> Result<f32, NotReady> {
         self.check_status(Status::Configured)?;
 
-        fonts()
+        fonts::fonts()
             .get_first_face(self.get_font())
             .map(|face| face.height(self.get_font_size()))
             .map_err(|_| {

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,28 +5,28 @@
 
 //! Utility types and traits
 
-/// Describes required text-preparation actions
+/// Describes the state-of-preparation of a [`TextDisplay`][crate::TextDisplay]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub enum Action {
-    /// Nothing to do
-    None,
-    /// Fix vertical alignment
-    VAlign,
-    /// Do wrapping and alignment
-    Wrap,
-    /// Resize text, and above
-    Resize,
-    /// Break text into runs, associate fonts, and above
-    Break,
-    /// Configure text
-    Configure,
+pub enum Status {
+    /// Nothing done yet
+    New,
+    /// Configured
+    Configured,
+    /// As [`Self::LevelRuns`], except these need resizing
+    ResizeLevelRuns,
+    /// Source text has been broken into level runs
+    LevelRuns,
+    /// Line wrapping and horizontal alignment is done
+    Wrapped,
+    /// The text is ready for display
+    Ready,
 }
 
-impl Action {
-    /// True if action is `Action::None`
+impl Status {
+    /// True if status is `Status::Ready`
     #[inline]
     pub fn is_ready(&self) -> bool {
-        *self == Action::None
+        *self == Status::Ready
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,7 +17,9 @@ pub enum Action {
     /// Resize text, and above
     Resize,
     /// Break text into runs, associate fonts, and above
-    All,
+    Break,
+    /// Configure text
+    Configure,
 }
 
 impl Action {

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,9 +6,10 @@
 //! Utility types and traits
 
 /// Describes the state-of-preparation of a [`TextDisplay`][crate::TextDisplay]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum Status {
     /// Nothing done yet
+    #[default]
     New,
     /// Configured
     Configured,


### PR DESCRIPTION
- All fields of `Environment` are moved into `Text`
- `Action` is replaced with `Status` (mostly because I found the ordering of `Action` unintuitive)
- Status-tracking is moved from `TextDisplay` to `Text`
- Added `Text::configure`. It really only asserts that a valid `FontId` is used.
- `wrap: bool` is replaced with `wrap_width: f32`, independent of the horizontal bounds used for alignment.
- Better documentation of preparation status and usage.
- Remove `Deref`, `DerefMut`, `AsRef` and `AsMut` impls on `Text`
- `fn TextApi::display` replaced with `unchecked_display` and `TextApiExt::display(&self) -> `Result<&TextDisplay, NotReady>`
- Rename `crate::fonts::fonts` to `crate::fonts::library`

This should make `Text` easier to use and facilitate custom variants of `Text`.