### PR TITLE
Support font synthesis; remove deps harfbuzz-rs & fontdue; update deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,9 @@ jobs:
         run: |
           cargo fmt --all -- --check
       - name: doc
-        run: RUSTDOCFLAGS="--cfg doc_cfg" cargo doc --features markdown,num_glyphs --no-deps
-      - name: Test Harfbuzz
-        run: cargo test --all-targets --features harfbuzz
+        run: RUSTDOCFLAGS="--cfg doc_cfg" cargo doc --all-features --no-deps
       - name: Clippy
-        run: cargo +nightly clippy --features shaping,markdown,serde,num_glyphs
+        run: cargo +nightly clippy --all-features
       - name: Test (all features including GAT)
         run: cargo test --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ serde = ["dep:serde", "bitflags/serde"]
 
 # Backends to expose fonts for
 ab_glyph = ["dep:ab_glyph"]
-fontdue = ["dep:fontdue"]
 # Deprecated feature flag (now always enabled):
 swash = []
 
@@ -53,7 +52,6 @@ pulldown-cmark = { version = "0.13.0", optional = true }
 log = "0.4"
 serde = { version = "1.0.123", features = ["derive"], optional = true }
 ab_glyph = { version = "0.2.10", optional = true }
-fontdue = { version = "0.9.2", optional = true }
 swash = "0.2.4"
 fontique = "0.5.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ tinyvec = { version = "1.9.0", features = ["alloc"] }
 unicode-bidi = "0.3.4"
 unicode-bidi-mirroring = "0.3.0"
 thiserror = "1.0.20"
-pulldown-cmark = { version = "0.12.0", optional = true }
+pulldown-cmark = { version = "0.13.0", optional = true }
 log = "0.4"
 serde = { version = "1.0.123", features = ["derive"], optional = true }
 ab_glyph = { version = "0.2.10", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ swash = []
 cfg-if = "1.0.0"
 easy-cast = "0.5.0"
 bitflags = "2.4.2"
-ttf-parser = "0.24.1"
+ttf-parser = "0.25.1"
 smallvec = "1.6.1"
 tinyvec = { version = "1.9.0", features = ["alloc"] }
 unicode-bidi = "0.3.4"
@@ -60,7 +60,7 @@ swash = "0.2.4"
 fontique = "0.5.0"
 
 [dependencies.rustybuzz]
-version = "0.18.0"
+version = "0.20.1"
 optional = true
 
 [dependencies.harfbuzz_rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kas-text"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -15,8 +15,8 @@ rust-version = "1.82.0"
 
 [package.metadata.docs.rs]
 # To build locally:
-# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features num_glyphs,markdown --no-deps --open
-features = ["markdown", "num_glyphs"]
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps --open
+all-features = true
 
 [features]
 # Support num_glyphs method
@@ -33,10 +33,8 @@ markdown = ["pulldown-cmark"]
 # Serialization is optionally supported for some types:
 serde = ["dep:serde", "bitflags/serde"]
 
-# Backends to expose fonts for
+# Optional: expose ab_glyph font face
 ab_glyph = ["dep:ab_glyph"]
-# Deprecated feature flag (now always enabled):
-swash = []
 
 [dependencies]
 cfg-if = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ ttf-parser = "0.25.1"
 smallvec = "1.6.1"
 tinyvec = { version = "1.9.0", features = ["alloc"] }
 unicode-bidi = "0.3.4"
-unicode-bidi-mirroring = "0.3.0"
-thiserror = "1.0.20"
+unicode-bidi-mirroring = "0.4.0"
+thiserror = "2.0.12"
 pulldown-cmark = { version = "0.13.0", optional = true }
 log = "0.4"
 serde = { version = "1.0.123", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,6 @@ num_glyphs = []
 shaping = ["rustybuzz"]
 # Enable shaping via rustybuzz.
 rustybuzz = ["dep:rustybuzz"]
-# Enable shaping via HarfBuzz.
-harfbuzz = ["shaping", "dep:harfbuzz_rs"]
 
 # Enable Markdown parsing
 markdown = ["pulldown-cmark"]
@@ -61,10 +59,6 @@ fontique = "0.5.0"
 
 [dependencies.rustybuzz]
 version = "0.20.1"
-optional = true
-
-[dependencies.harfbuzz_rs]
-version = "2.0"
 optional = true
 
 [lints.clippy]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ More on what Kas-text does do:
 
 Rich text support is limited to changing font properties (e.g. weight, italic), size, family and underline/strikethrough decorations. A (very limited) Markdown processor is included to facilitate construction of these texts using the lower-level `FormattableText` trait.
 
-Glyph rastering and painting is not implemented here, though `kas-text` can provide font references for [Swash], [Fontdue] (optional) and [ab_glyph] (optional) libraries. Check the [`kas-wgpu`] code for an example of rastering and painting.
+Glyph rastering and painting is not implemented here, though `kas-text` can provide font references for [Swash] and (optionally) [ab_glyph] libraries. Check the [`kas-wgpu`] code for an example of rastering and painting.
 
 Text editing is only supported via a low-level API. [`kas_widgets::edit::EditField`](https://docs.rs/kas-widgets/latest/kas_widgets/edit/struct.EditField.html) is a simple editor built over this API.
 
@@ -75,7 +75,6 @@ the following web page: <https://www.apache.org/licenses/LICENSE-2.0>
 
 
 [ab_glyph]: https://github.com/alexheretic/ab-glyph
-[Fontdue]: https://github.com/mooman219/fontdue
 [Swash]: https://github.com/dfrg/swash
 [Parley]: https://github.com/linebender/parley
 [COSMIC Text]: https://github.com/linebender/parley

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ More on what Kas-text does do:
 - [x] Font discovery via [Fontique](https://github.com/linebender/parley?tab=readme-ov-file#fontique)
 - [x] Font loading and management
 - [x] Script-aware font selection and glyph-level fallback
-- [x] Text layout via a choice of [HarfBuzz](https://github.com/harfbuzz/harfbuzz), [rustybuzz](https://github.com/harfbuzz/rustybuzz) or a simple built-in shaper
+- [x] Text layout via a choice of [rustybuzz](https://github.com/harfbuzz/rustybuzz) or a simple built-in shaper
 - [ ] Vertical text support
 - [x] Supports bi-directional texts
 - [x] A low-level API for text editing including logical-order and mouse navigation

--- a/README.md
+++ b/README.md
@@ -1,43 +1,33 @@
-KAS Text
-==========
+Kas Text
+========
 
 [![kas](https://img.shields.io/badge/GitHub-kas-blueviolet)](https://github.com/kas-gui/kas/)
 [![Docs](https://docs.rs/kas-text/badge.svg)](https://docs.rs/kas-text/)
 
 A pure-Rust rich-text processing library suitable for KAS and other GUI tools.
 
-What it does (or may in the future) do:
+Kas-text is intended to address the needs of common GUI text tasks: fast, able to handle plain text well in common scripts including common effects like bold text and underline, along with support for editing plain texts.
 
-- [x] Font discovery (very limited; system configuration is ignored)
-- [x] Font fallback for missing glyphs
-- [x] Text layout: yield a sequence of positioned glyphs
-- [x] Supports bi-directional text
-- [x] Text shaping (optional) via [rustybuzz](https://github.com/RazrFalcon/rustybuzz) or [harfbuzz](http://harfbuzz.org/)
-- [ ] Handle combining diacritics correctly
-- [x] Support position navigation / lookup
+More on what Kas-text does do:
+
+- [x] Font discovery via [Fontique](https://github.com/linebender/parley?tab=readme-ov-file#fontique)
+- [x] Font loading and management
+- [x] Script-aware font selection and glyph-level fallback
+- [x] Text layout via a choice of [HarfBuzz](https://github.com/harfbuzz/harfbuzz), [rustybuzz](https://github.com/harfbuzz/rustybuzz) or a simple built-in shaper
+- [ ] Vertical text support
+- [x] Supports bi-directional texts
+- [x] A low-level API for text editing including logical-order and mouse navigation
+- [ ] Visual-order navigation
 - [ ] Sub-ligature navigation
-- [ ] Visual-order BIDI text navigation
-- [ ] Emoticons
-- [x] Rich text: choose font by style/weight/family for a sub-range
-- [x] Text annotations: highlight range, underline
-- [x] Raster glyphs (via `ab_glyph` or `fontdue`)
-- [x] Fast-ish: good enough for snappy GUIs; further optimisation possible
+- [x] Font styles (weight, width, italic)
+- [x] Text decorations: highlight range, underline
+- [x] Decently optimized: good enough for snappy GUIs
 
-What it does not do:
+Rich text support is limited to changing font properties (e.g. weight, italic), size, family and underline/strikethrough decorations. A (very limited) Markdown processor is included to facilitate construction of these texts using the lower-level `FormattableText` trait.
 
--   Draw: rastering glyphs yields a sequence of sprites. Caching these in a
-    glyph atlas and rendering to a texture is beyond the scope of this project
-    since it is dependent on the graphics libraries used.
--   Editing: mapping input actions (e.g. from a winit `WindowEvent`) to text
-    edit operations is beyond the scope of this project. The API *does* cover
-    replacing text ranges and finding the nearest glyph index to a coordinate.
--   Rich text: there is no packaged format for rich text. A `FormattableText`
-    trait and a (limited) Markdown processor are included.
--   Full text layout: there is no support for custom inter-paragraph gaps,
-    inter-line gaps, embedded images, or horizontal rules.
+Glyph rastering and painting is not implemented here, though `kas-text` can provide font references for [Swash], [Fontdue] (optional) and [ab_glyph] (optional) libraries. Check the [`kas-wgpu`] code for an example of rastering and painting.
 
-For more, see the initial [design document](design/requirements.md) and
-[issue #1](https://github.com/kas-gui/kas-text/issues/1).
+Text editing is only supported via a low-level API. [`kas_widgets::edit::EditField`](https://docs.rs/kas-widgets/latest/kas_widgets/edit/struct.EditField.html) is a simple editor built over this API.
 
 
 Examples
@@ -54,12 +44,9 @@ Alternatives
 
 Pure-Rust alternatives for typesetting and rendering text:
 
--   [Swash](https://github.com/dfrg/swash): font introspection, shaping, character and script analysis, rendering
--   [fontdue](https://github.com/mooman219/fontdue): rastering and simple layout
--   [glyph_brush](https://github.com/alexheretic/glyph-brush): rendering and simple layout
-
-Non-pure-Rust alternatives include [font-kit](https://crates.io/crates/font-kit)
-and [piet](https://crates.io/crates/piet) among others.
+-   [Parley] provides an API for implementing rich text layout. It is backed by [Swash].
+-   [COSMIC Text] provides advanced text shaping, layout, and rendering wrapped up into a simple abstraction.
+-   [glyph_brush](https://github.com/alexheretic/glyph-brush) is a fast caching text render library using [ab_glyph].
 
 
 Contributing
@@ -68,12 +55,11 @@ Contributing
 Contributions are welcome. For the less straightforward contributions it is
 advisable to discuss in an issue before creating a pull-request.
 
-Testing is currently done in a very ad-hoc manner via KAS examples. This is
-facilitated by tying KAS commits to kas-text commit hashes during development
-and allows testing editing as well as display.
-A comprehensive test framework must consider a *huge* number of cases and the
-test framework alone would constitute considerably more work than building this
-library, so for now user-testing and bug reports will have to suffice.
+Testing is done in an ad-hoc manner using examples. The [Layout Demo](https://github.com/kas-gui/kas/tree/master/examples#layout) often proves useful for quick tests. It helps to use a patch like that below in `kas/Cargo.toml`:
+```toml
+[patch.crates-io.kas-text]
+path = "../kas-text"
+```
 
 
 Copyright and License
@@ -86,3 +72,11 @@ optionally add themselves to this list.
 The KAS library is published under the terms of the Apache License, Version 2.0.
 You may obtain a copy of this license from the [LICENSE](LICENSE) file or on
 the following web page: <https://www.apache.org/licenses/LICENSE-2.0>
+
+
+[ab_glyph]: https://github.com/alexheretic/ab-glyph
+[Fontdue]: https://github.com/mooman219/fontdue
+[Swash]: https://github.com/dfrg/swash
+[Parley]: https://github.com/linebender/parley
+[COSMIC Text]: https://github.com/linebender/parley
+[`kas-wgpu`]: https://crates.io/crates/kas-wgpu

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -35,7 +35,7 @@ pub fn to_usize(x: u32) -> usize {
 pub struct DPU(pub f32);
 
 impl DPU {
-    #[cfg(all(not(feature = "harfbuzz"), feature = "rustybuzz"))]
+    #[cfg(feature = "rustybuzz")]
     pub(crate) fn i32_to_px(self, x: i32) -> f32 {
         x as f32 * self.0
     }

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -160,10 +160,8 @@ impl TextDisplay {
             // Force end of current run?
             let bidi_break = levels[pos] != input.level;
 
-            let mut fmt_break = false;
             if let Some(fmt) = next_fmt.as_ref() {
                 if to_usize(fmt.start) == pos {
-                    fmt_break = true;
                     font = fmt.font;
                     dpem = fmt.dpem;
                     next_fmt = font_tokens.next();
@@ -189,7 +187,7 @@ impl TextDisplay {
                 .or(face_id);
             let font_break = face_id.is_some() && new_face_id != face_id;
 
-            if hard_break || control_break || bidi_break || fmt_break || font_break {
+            if hard_break || control_break || bidi_break || font_break {
                 // TODO: sometimes this results in empty runs immediately
                 // following another run. Ideally we would either merge these
                 // into the previous run or not simply break in this case.

--- a/src/fonts/face.rs
+++ b/src/fonts/face.rs
@@ -57,17 +57,11 @@ impl<'a> FaceRef<'a> {
     pub fn scale_by_dpu(self, dpu: DPU) -> ScaledFaceRef<'a> {
         ScaledFaceRef(self.0, dpu)
     }
-
-    /// Get the height of horizontal text in pixels
-    ///
-    /// Units: `dpem` is dots (pixels) per Em (module documentation).
-    #[inline]
-    pub fn height(&self, dpem: f32) -> f32 {
-        self.scale_by_dpem(dpem).height()
-    }
 }
 
 /// Handle to a loaded font face
+///
+/// TODO: verify whether these values need adjustment for variations.
 #[derive(Copy, Clone, Debug)]
 pub struct ScaledFaceRef<'a>(&'a Face<'a>, DPU);
 impl<'a> ScaledFaceRef<'a> {

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -23,18 +23,8 @@ enum FontError {
     #[cfg(feature = "ab_glyph")]
     #[error("font load error")]
     AbGlyph(#[from] ab_glyph::InvalidFont),
-    #[cfg(feature = "fontdue")]
-    #[error("font load error")]
-    StrError(&'static str),
     #[error("font load error")]
     Swash,
-}
-
-#[cfg(feature = "fontdue")]
-impl From<&'static str> for FontError {
-    fn from(msg: &'static str) -> Self {
-        FontError::StrError(msg)
-    }
 }
 
 /// Bad [`FontId`] or no font loaded
@@ -91,8 +81,6 @@ pub struct FaceStore {
     rustybuzz: rustybuzz::Face<'static>,
     #[cfg(feature = "ab_glyph")]
     ab_glyph: ab_glyph::FontRef<'static>,
-    #[cfg(feature = "fontdue")]
-    fontdue: fontdue::Font,
     swash: (u32, swash::CacheKey), // (offset, key)
     synthesis: Synthesis,
 }
@@ -140,15 +128,6 @@ impl FaceStore {
                 }
                 font
             },
-            #[cfg(feature = "fontdue")]
-            fontdue: {
-                let settings = fontdue::FontSettings {
-                    collection_index: index,
-                    scale: 40.0, // TODO: max expected font size in dpem
-                    load_substitutions: true,
-                };
-                fontdue::Font::from_bytes(data, settings)?
-            },
             swash: {
                 use easy_cast::Cast;
                 let f = swash::FontRef::from_index(data, index.cast()).ok_or(FontError::Swash)?;
@@ -178,12 +157,6 @@ impl FaceStore {
     #[cfg(feature = "ab_glyph")]
     pub fn ab_glyph(&self) -> &ab_glyph::FontRef<'static> {
         &self.ab_glyph
-    }
-
-    /// Access the [`fontdue`] object
-    #[cfg(feature = "fontdue")]
-    pub fn fontdue(&self) -> &fontdue::Font {
-        &self.fontdue
     }
 
     /// Get a swash `FontRef`

--- a/src/fonts/library.rs
+++ b/src/fonts/library.rs
@@ -87,8 +87,6 @@ pub struct FaceStore {
     blob: Blob<u8>,
     index: u32,
     face: Face<'static>,
-    #[cfg(feature = "harfbuzz")]
-    harfbuzz: harfbuzz_rs::Shared<harfbuzz_rs::Face<'static>>,
     #[cfg(feature = "rustybuzz")]
     rustybuzz: rustybuzz::Face<'static>,
     #[cfg(feature = "ab_glyph")]
@@ -134,8 +132,6 @@ impl FaceStore {
                 rustybuzz
             },
             face,
-            #[cfg(feature = "harfbuzz")]
-            harfbuzz: harfbuzz_rs::Face::from_bytes(data, index).into(),
             #[cfg(feature = "ab_glyph")]
             ab_glyph: {
                 let mut font = ab_glyph::FontRef::try_from_slice_and_index(data, index)?;
@@ -170,18 +166,6 @@ impl FaceStore {
     /// Access a [`FaceRef`] object
     pub fn face_ref(&self) -> FaceRef<'_> {
         FaceRef(&self.face)
-    }
-
-    /// Access the [`harfbuzz_rs`] object
-    #[cfg(feature = "harfbuzz")]
-    pub fn harfbuzz(&self) -> &harfbuzz_rs::Shared<harfbuzz_rs::Face<'static>> {
-        &self.harfbuzz
-    }
-
-    /// Access an owned [`harfbuzz_rs`] object
-    #[cfg(feature = "harfbuzz")]
-    pub fn harfbuzz_owned(&self) -> harfbuzz_rs::Owned<harfbuzz_rs::Font<'static>> {
-        harfbuzz_rs::Font::new(self.harfbuzz.clone())
     }
 
     /// Access the [`rustybuzz`] object

--- a/src/format/markdown.rs
+++ b/src/format/markdown.rs
@@ -418,7 +418,7 @@ impl StackItem {
             }
             Tag::Superscript | Tag::Subscript => {
                 // kas-text doesn't support adjusting the baseline
-                return Err(Error::NotSupported("super/subscript"))
+                return Err(Error::NotSupported("super/subscript"));
             }
             Tag::Link { .. } => return Err(Error::NotSupported("link")),
             Tag::Image { .. } => return Err(Error::NotSupported("image")),

--- a/src/format/markdown.rs
+++ b/src/format/markdown.rs
@@ -416,6 +416,10 @@ impl StackItem {
             Tag::Table(_) | Tag::TableHead | Tag::TableRow | Tag::TableCell => {
                 return Err(Error::NotSupported("table"))
             }
+            Tag::Superscript | Tag::Subscript => {
+                // kas-text doesn't support adjusting the baseline
+                return Err(Error::NotSupported("super/subscript"))
+            }
             Tag::Link { .. } => return Err(Error::NotSupported("link")),
             Tag::Image { .. } => return Err(Error::NotSupported("image")),
             Tag::MetadataBlock(_) => return Err(Error::NotSupported("metadata block")),


### PR DESCRIPTION
Font synthesis is now propagated and applied to `ab_glyph` and `rustybuzz` font faces (Swash requires this be applied downstream when rastering glyphs). Caveat: font metrics available through `ScaledFaceRef` are not adjusted; results when using font variations without `rustybuzz` may not account for adjusted glyph size properly while cursor position, highlights and decorations may not be perfect. So far my testing hasn't found any big issues however.

https://github.com/harfbuzz/harfbuzz_rs is removed as a dependency since it appears to be unmaintained and is redundant with `rustybuzz`. https://github.com/mooman219/fontdue is removed as a dependency since it doesn't appear to support font synthesis and is redundant with `ab_glyph` *and* `swash`.

The `kas-text` version is bumped to v0.8.0 since there are breaking changes, though release is not planned just yet. README tweaks.