### PR TITLE
Revert "Use emoji font for emojis"

### DIFF
--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -144,9 +144,6 @@ impl TextDisplay {
     /// Must be called again if any of `text`, `direction` or `font` change.
     /// If only `dpem` changes, [`Self::resize_runs`] may be called instead.
     ///
-    /// If `use_emoji_font` then emojis will use a special emoji font, otherwise
-    /// the usual font fallbacks may resolve a line-art emoji.
-    ///
     /// The text is broken into a set of contiguous "level runs". These runs are
     /// maximal slices of the `text` which do not contain explicit line breaks
     /// and have a single text direction according to the
@@ -157,7 +154,6 @@ impl TextDisplay {
         direction: Direction,
         mut font: FontSelector,
         mut dpem: f32,
-        use_emoji_font: bool,
     ) -> Result<(), NoFontMatch> {
         // This method constructs a list of "hard lines" (the initial line and any
         // caused by a hard break), each composed of a list of "level runs" (the
@@ -211,7 +207,6 @@ impl TextDisplay {
 
         let mut last_is_control = false;
         let mut last_is_htab = false;
-        let mut last_is_emoji = false;
         let mut non_control_end = 0;
 
         for (index, c) in text.char_indices() {
@@ -221,12 +216,10 @@ impl TextDisplay {
             }
             let is_control = c.is_control();
             let is_htab = c == '\t';
-            let mut require_break = is_htab || (last_is_control && !is_control);
+            let control_break = is_htab || (last_is_control && !is_control);
 
             let (props, boundary) = analyzer.next().unwrap();
             last_props = Some(props);
-            let is_emoji = use_emoji_font && props.is_emoji();
-            require_break |= is_emoji != last_is_emoji;
 
             // Forcibly end the line?
             let hard_break = boundary == Boundary::Mandatory;
@@ -234,7 +227,7 @@ impl TextDisplay {
             let is_break = hard_break || boundary == Boundary::Line;
 
             // Force end of current run?
-            require_break |= levels[index] != input.level;
+            let bidi_break = levels[index] != input.level;
 
             if let Some(fmt) = next_fmt.as_ref()
                 && to_usize(fmt.start) == index
@@ -257,7 +250,7 @@ impl TextDisplay {
                 }
             }
 
-            if hard_break || require_break || new_script.is_some() {
+            if hard_break || control_break || bidi_break || new_script.is_some() {
                 let range = (start..non_control_end).into();
                 let special = match () {
                     _ if hard_break => RunSpecial::HardBreak,
@@ -266,12 +259,7 @@ impl TextDisplay {
                     _ => RunSpecial::NoBreak,
                 };
 
-                let f = if last_is_emoji {
-                    FontSelector::EMOJI
-                } else {
-                    font
-                };
-                self.push_run(f, input, range, breaks, special, first_real)?;
+                self.push_run(font, input, range, breaks, special, first_real)?;
                 first_real = None;
 
                 start = index;
@@ -287,7 +275,6 @@ impl TextDisplay {
 
             last_is_control = is_control;
             last_is_htab = is_htab;
-            last_is_emoji = is_emoji;
             input.dpem = dpem;
             if let Some(script) = new_script {
                 input.script = script;
@@ -310,12 +297,7 @@ impl TextDisplay {
             _ => RunSpecial::None,
         };
 
-        let f = if last_is_emoji {
-            FontSelector::EMOJI
-        } else {
-            font
-        };
-        self.push_run(f, input, range, breaks, special, first_real)?;
+        self.push_run(font, input, range, breaks, special, first_real)?;
 
         // Following a hard break we have an implied empty line.
         if hard_break {

--- a/src/fonts/resolver.rs
+++ b/src/fonts/resolver.rs
@@ -224,14 +224,6 @@ pub struct FontSelector {
 }
 
 impl FontSelector {
-    /// Hard-coded emoji font selector
-    pub const EMOJI: Self = FontSelector {
-        family: FamilySelector::EMOJI,
-        weight: FontWeight::NORMAL,
-        width: FontWidth::NORMAL,
-        style: FontStyle::Normal,
-    };
-
     /// Synonym for default
     ///
     /// Without further parametrization, this will select a generic sans-serif

--- a/src/text.rs
+++ b/src/text.rs
@@ -395,7 +395,7 @@ impl<T: FormattableText + ?Sized> Text<T> {
         match self.status {
             Status::New => {
                 self.display
-                    .prepare_runs(&self.text, self.direction, self.font, self.dpem, true)?
+                    .prepare_runs(&self.text, self.direction, self.font, self.dpem)?
             }
             Status::ResizeLevelRuns => self.display.resize_runs(&self.text, self.dpem),
             _ => (),


### PR DESCRIPTION
This reverts commit 5c768583ff5731813286361d0c628e76c5970b19.

It turns out that `props.is_emoji` means "has emoji presentation mode", not "uses emoji presentation mode by default", resulting in using emojis for ordinary numeric characters (among others).

Emoji support is not a priority, hence reverting rather than fixing this.