### PR TITLE
Use emoji font for emojis

### DIFF
--- a/src/fonts/resolver.rs
+++ b/src/fonts/resolver.rs
@@ -224,6 +224,14 @@ pub struct FontSelector {
 }
 
 impl FontSelector {
+    /// Hard-coded emoji font selector
+    pub const EMOJI: Self = FontSelector {
+        family: FamilySelector::EMOJI,
+        weight: FontWeight::NORMAL,
+        width: FontWidth::NORMAL,
+        style: FontStyle::Normal,
+    };
+
     /// Synonym for default
     ///
     /// Without further parametrization, this will select a generic sans-serif


### PR DESCRIPTION
Re-enables emoji support (see #114) using ICU4X properties.

This is enough for *basic* Emoji support but not to deal with emoji modifiers or non-default presentation modes.