### PR TITLE
Disable font-fallback breaking in tests

### DIFF
--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -709,11 +709,10 @@ mod test {
         test_breaking(sample, Direction::Rtl, &expected_rtl[..]);
     }
 
+    // Additional tests for right-to-left languages: Hebrew, Arabic.
+    // Samples are translations of the first article of the UDHR from https://r12a.github.io/
     #[test]
-    fn test_breaking_rtl() {
-        // Additional tests for right-to-left languages: Hebrew, Arabic.
-        // Samples are translations of the first article of the UDHR from https://r12a.github.io/
-
+    fn test_breaking_hebrew() {
         let sample = "סעיף א. כל בני אדם נולדו בני חורין ושווים בערכם ובזכויותיהם. כולם חוננו בתבונה ובמצפון, לפיכך חובה עליהם לנהוג איש ברעהו ברוח של אחוה.";
         test_breaking(
             sample,
@@ -729,7 +728,10 @@ mod test {
                 ],
             )],
         );
+    }
 
+    #[test]
+    fn test_breaking_arabic() {
         let sample = "المادة 1 يولد جميع الناس أحرارًا متساوين في الكرامة والحقوق. وقد وهبوا عقلاً وضميرًا وعليهم أن يعامل بعضهم بعضًا بروح الإخاء.";
         test_breaking(
             sample,
@@ -757,9 +759,6 @@ mod test {
         );
     }
 
-    // TODO: find a way to enable this test which is permissive of font
-    // variability (namely whether or not font fallbacks cause extra breaks).
-    #[cfg(false)]
     #[test]
     fn test_breaking_complex_arabic() {
         // Another, more complex, Arabic sample. Source: https://r12a.github.io/scripts/tutorial/summaries/arabic
@@ -790,20 +789,11 @@ mod test {
                     &[55],
                 ),
                 (
-                    58..196,
+                    58..197,
                     RunSpecial::NoBreak,
                     Level::rtl(),
                     Script::Arabic,
-                    &[62, 69, 82, 91, 107, 118, 127, 138, 153, 166, 179],
-                ),
-                (
-                    // Note that this break occurs due to font fallback where
-                    // the Arabic font doesn't contain a (round) bracket.
-                    196..197,
-                    RunSpecial::NoBreak,
-                    Level::rtl(),
-                    Script::Arabic,
-                    &[],
+                    &[62, 69, 82, 91, 107, 118, 127, 138, 153, 166, 179, 196],
                 ),
                 (
                     197..215,
@@ -813,16 +803,7 @@ mod test {
                     &[205],
                 ),
                 (
-                    // Note that this break occurs due to font fallback where
-                    // the Arabic font doesn't contain a (round) bracket.
-                    215..216,
-                    RunSpecial::NoBreak,
-                    Level::rtl(),
-                    Script::Arabic,
-                    &[],
-                ),
-                (
-                    216..244,
+                    215..244,
                     RunSpecial::None,
                     Level::rtl(),
                     Script::Arabic,

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -70,6 +70,7 @@ impl TextDisplay {
     /// Resolve font face and shape run
     ///
     /// This may sub-divide text as required to find matching fonts.
+    #[cfg_attr(test, allow(unused_mut))]
     fn push_run(
         &mut self,
         font: FontSelector,
@@ -101,11 +102,14 @@ impl TextDisplay {
         let mut face = preferred_face;
 
         let mut start = 0;
+        #[cfg_attr(test, allow(unused_variables))]
         for (index, c) in text.char_indices() {
             if DefaultIgnorableCodePoint::for_char(c) {
                 continue;
             }
 
+            // HACK: disable font-fallback breaking in tests to get repeatable results
+            #[cfg(not(test))]
             if let Some(new_face) = fonts
                 .face_for_char(font_id, Some(preferred_face), c)
                 .expect("invalid FontId")


### PR DESCRIPTION
A quick hack to make run-breaking tests independent of system fonts. Using a mock component for testing would require more extensive code changes.

The tests in `shaper.rs` also pass without feature "shaping"; *with* "shaping" I believe only the Arabic test is font-dependent.