### PR TITLE
Replace BiDi level inference: add `GlyphRun::base_level`

### DIFF
--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -6,7 +6,7 @@
 //! Text prepared for display
 
 #[allow(unused)]
-use crate::Text;
+use crate::{Status, Text};
 use crate::conv::to_usize;
 use crate::{Direction, Vec2, shaper};
 use smallvec::SmallVec;
@@ -37,33 +37,24 @@ pub struct NotReady;
 ///
 /// ### Status of preparation
 ///
-/// Stages of preparation are as follows:
+/// This struct does not track the state-of-preparation internally. It is
+/// recommended to use [`Text`] or a custom wrapper to do this. The [`Status`]
+/// enum may be helpful here.
 ///
-/// 1.  Ensure all required [fonts](crate::fonts) are loaded.
-/// 2.  Call [`Self::prepare_runs`] to break text into level runs, then shape
-///     these runs into glyph runs (unwrapped but with weak break points).
+/// Methods note the expected status-of-preparation. Violating this expectation
+/// is memory-safe but may cause a panic or an unexpected result.
 ///
-///     This method must be called again if the `text`, text `direction` or
-///     `font_id` change. If only the text size (`dpem`) changes, it is
-///     sufficient to instead call [`Self::resize_runs`].
-/// 3.  Optionally, [`Self::measure_width`] and [`Self::measure_height`] may be
-///     used at this point to determine size requirements.
-/// 4.  Call [`Self::prepare_lines`] to wrap text and perform re-ordering (where
-///     lines are bi-directional) and horizontal alignment.
+/// Steps of preparation are as follows:
 ///
-///     This must be called again if any of `wrap_width`, `width_bound` or
-///     `h_align` change.
-/// 5.  Call [`Self::vertically_align`] to set or adjust vertical alignment.
-///     (Not technically required if alignment is always top.)
-///
-/// All methods are idempotent (that is, they may be called multiple times
-/// without affecting the result). Later stages of preparation do not affect
-/// earlier stages, but if an earlier stage is repeated to account for adjusted
-/// configuration then later stages must also be repeated.
-///
-/// This struct does not track the state of preparation. It is recommended to
-/// use [`Text`] or a custom wrapper for that purpose. Failure to observe the
-/// correct sequence is memory-safe but may cause panic or an unexpected result.
+/// 1.  Run-breaking: call [`Self::prepare_runs`] to break text into runs,
+///     resolve fonts and apply shaping. (This is the most expensive step,
+///     especially when shaping is enabled.)
+/// 2.  (Optional) Measure size requirements using [`Self::measure_width`] and
+///     [`Self::measure_height`].
+/// 3.  Line-wrapping: call [`Self::prepare_lines`] to perform line-wrapping at
+///     the given wrap-width. This also re-orders segments (where lines are
+///     bi-directional) and performs horizontal alignment.
+/// 4.  (Optional) Tweak alignment (e.g. to vertically center text).
 ///
 /// ### Text navigation
 ///

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -5,10 +5,10 @@
 
 //! Text prepared for display
 
-#[allow(unused)]
-use crate::{Status, Text};
 use crate::conv::to_usize;
-use crate::{Direction, Vec2, shaper};
+#[allow(unused)]
+use crate::{Direction, Status, Text};
+use crate::{Vec2, shaper};
 use smallvec::SmallVec;
 use tinyvec::TinyVec;
 
@@ -76,12 +76,8 @@ pub struct NotReady;
 /// which provides a
 /// [`GraphemeCursor`](https://unicode-rs.github.io/unicode-segmentation/unicode_segmentation/struct.GraphemeCursor.html)
 /// to step back or forward one "grapheme", in logical text order.
-/// Optionally, the direction may
-/// be reversed for right-to-left lines [`TextDisplay::line_is_rtl`], but note
-/// that the result may be confusing since not all text on the line follows the
-/// line's base direction and adjacent lines may have different directions.
-///
-/// Navigating glyphs left or right in display-order is not currently supported.
+/// The direction of navigation may be reversed for [right-to-left text](Self::text_is_rtl)
+/// (i.e. reversed logical-order navigation).
 ///
 /// To navigate "up" and "down" lines, use [`TextDisplay::text_glyph_pos`] to
 /// get the position of the cursor, [`TextDisplay::find_line`] to get the line
@@ -114,10 +110,10 @@ pub struct TextDisplay {
 fn size_of_elts() {
     use std::mem::size_of;
     assert_eq!(size_of::<TinyVec<[u8; 0]>>(), 24);
-    assert_eq!(size_of::<shaper::GlyphRun>(), 112);
+    assert_eq!(size_of::<shaper::GlyphRun>(), 120);
     assert_eq!(size_of::<RunPart>(), 24);
     assert_eq!(size_of::<Line>(), 24);
-    assert_eq!(size_of::<TextDisplay>(), 200);
+    assert_eq!(size_of::<TextDisplay>(), 208);
 }
 
 impl Default for TextDisplay {
@@ -199,26 +195,18 @@ impl TextDisplay {
         first
     }
 
-    /// Get the base directionality of the text
+    /// Get the base directionality of the first paragraph
     ///
-    /// [Requires status][Self#status-of-preparation]: none.
-    pub fn text_is_rtl(&self, text: &str, direction: Direction) -> bool {
-        let (is_auto, mut is_rtl) = match direction {
-            Direction::Ltr => (false, false),
-            Direction::Rtl => (false, true),
-            Direction::Auto => (true, false),
-            Direction::AutoRtl => (true, true),
-        };
-
-        if is_auto {
-            match unicode_bidi::get_base_direction(text) {
-                unicode_bidi::Direction::Ltr => is_rtl = false,
-                unicode_bidi::Direction::Rtl => is_rtl = true,
-                unicode_bidi::Direction::Mixed => (),
-            }
-        }
-
-        is_rtl
+    /// [Requires status][Self#status-of-preparation]: run-breaking is complete.
+    ///
+    /// This returns the direction inferred from the `text` and [`Direction`]
+    /// used during run-breaking. See also [`Direction::text_is_rtl`].
+    #[inline]
+    pub fn text_is_rtl(&self) -> bool {
+        self.runs
+            .first()
+            .map(|r| r.base_level.is_rtl())
+            .unwrap_or_default()
     }
 
     /// Get the directionality of the current line
@@ -227,16 +215,16 @@ impl TextDisplay {
     ///
     /// Returns:
     ///
-    /// - `None` if text is empty
+    /// - `None` if the line is not found
     /// - `Some(line_is_right_to_left)` otherwise
     ///
     /// Note: indeterminate lines (e.g. empty lines) have their direction
-    /// determined from the passed environment, by default left-to-right.
+    /// determined from the passed [`Direction`].
     pub fn line_is_rtl(&self, line: usize) -> Option<bool> {
         if let Some(line) = self.lines.get(line) {
             let first_run = line.run_range.start();
             let glyph_run = to_usize(self.wrapped_runs[first_run].glyph_run);
-            Some(self.runs[glyph_run].level.is_rtl())
+            Some(self.runs[glyph_run].base_level.is_rtl())
         } else {
             None
         }

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -34,8 +34,8 @@ pub(crate) enum RunSpecial {
 impl TextDisplay {
     /// Update font size
     ///
-    /// [Requires status][Self#status-of-preparation]: level runs have been
-    /// prepared and are valid in all ways except size (`dpem`).
+    /// [Requires status][Self#status-of-preparation]: run-breaking is complete
+    /// excepting that size (`dpem`) alterations may be required.
     ///
     /// Parameters must match those passed to [`Self::prepare_runs`] for the
     /// result to be valid.

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -58,6 +58,7 @@ impl TextDisplay {
             let input = shaper::Input {
                 text,
                 dpem,
+                base_level: run.base_level,
                 level: run.level,
                 script: run.script,
             };
@@ -213,15 +214,22 @@ impl TextDisplay {
             Direction::Rtl => Some(RTL_LEVEL),
         };
         let info = BidiInfo::new(text, default_para_level);
+        let default_level = direction.level();
         let levels = info.levels;
         assert_eq!(text.len(), levels.len());
 
         let mut input = shaper::Input {
             text,
             dpem,
-            level: levels.first().cloned().unwrap_or(LTR_LEVEL),
+            base_level: info
+                .paragraphs
+                .first()
+                .map(|p| p.level)
+                .unwrap_or(default_level),
+            level: levels.first().cloned().unwrap_or(default_level),
             script: Script::Unknown,
         };
+        let mut next_para_i = 1;
 
         let mut start = 0;
         let mut breaks = Default::default();
@@ -336,6 +344,12 @@ impl TextDisplay {
 
                 start = index;
                 non_control_end = index;
+                while let Some(para) = info.paragraphs.get(next_para_i)
+                    && para.range.start <= index
+                {
+                    input.base_level = para.level;
+                    next_para_i += 1;
+                }
                 if let Some(level) = levels.get(index) {
                     input.level = *level;
                 }
@@ -580,7 +594,7 @@ mod test {
     use std::ops::Range;
     use unicode_bidi::Level;
 
-    type Expected<'a> = &'a [(Range<usize>, RunSpecial, Level, Script, &'a [u32])];
+    type Expected<'a> = &'a [(Range<usize>, RunSpecial, Level, Level, Script, &'a [u32])];
 
     fn test_breaking(text: &str, dir: Direction, expected: Expected) {
         let fonts = iter::once(FontToken {
@@ -602,15 +616,70 @@ mod test {
                 run.special, expected.1,
                 "RunSpecial for text \"{text}\", run {i}"
             );
-            assert_eq!(run.level, expected.2, "for text \"{text}\", run {i}");
-            assert_eq!(run.script, expected.3, "for text \"{text}\", run {i}");
+            assert_eq!(run.base_level, expected.2, "for text \"{text}\", run {i}");
+            assert_eq!(run.level, expected.3, "for text \"{text}\", run {i}");
+            assert_eq!(run.script, expected.4, "for text \"{text}\", run {i}");
             assert_eq!(
                 run.breaks.iter().map(|b| b.index).collect::<Vec<_>>(),
-                expected.4,
+                expected.5,
                 "wrap-points for text \"{text}\", run {i}"
             );
         }
         assert_eq!(display.runs.len(), expected.len(), "number of runs");
+    }
+
+    #[test]
+    fn test_breaking_empty() {
+        let sample = "";
+
+        test_breaking(
+            sample,
+            Direction::Auto,
+            &[(
+                0..0,
+                RunSpecial::None,
+                Level::ltr(),
+                Level::ltr(),
+                Script::Unknown,
+                &[],
+            )],
+        );
+        test_breaking(
+            sample,
+            Direction::Ltr,
+            &[(
+                0..0,
+                RunSpecial::None,
+                Level::ltr(),
+                Level::ltr(),
+                Script::Unknown,
+                &[],
+            )],
+        );
+        test_breaking(
+            sample,
+            Direction::AutoRtl,
+            &[(
+                0..0,
+                RunSpecial::None,
+                Level::rtl(),
+                Level::rtl(),
+                Script::Unknown,
+                &[],
+            )],
+        );
+        test_breaking(
+            sample,
+            Direction::Rtl,
+            &[(
+                0..0,
+                RunSpecial::None,
+                Level::rtl(),
+                Level::rtl(),
+                Script::Unknown,
+                &[],
+            )],
+        );
     }
 
     #[test]
@@ -622,6 +691,7 @@ mod test {
             &[(
                 0..sample.len(),
                 RunSpecial::None,
+                Level::ltr(),
                 Level::ltr(),
                 Script::Latin,
                 &[7, 12],
@@ -636,15 +706,30 @@ mod test {
             sample,
             Direction::Auto,
             &[
-                (0..4, RunSpecial::None, Level::ltr(), Script::Latin, &[]),
+                (
+                    0..4,
+                    RunSpecial::None,
+                    Level::ltr(),
+                    Level::ltr(),
+                    Script::Latin,
+                    &[],
+                ),
                 (
                     4..21,
                     RunSpecial::NoBreak,
+                    Level::ltr(),
                     Level::rtl(),
                     Script::Hebrew,
                     &[11],
                 ),
-                (21..25, RunSpecial::None, Level::ltr(), Script::Latin, &[22]),
+                (
+                    21..25,
+                    RunSpecial::None,
+                    Level::ltr(),
+                    Level::ltr(),
+                    Script::Latin,
+                    &[22],
+                ),
             ],
         );
 
@@ -653,10 +738,18 @@ mod test {
             sample,
             Direction::Auto,
             &[
-                (0..7, RunSpecial::None, Level::rtl(), Script::Hebrew, &[]),
+                (
+                    0..7,
+                    RunSpecial::None,
+                    Level::rtl(),
+                    Level::rtl(),
+                    Script::Hebrew,
+                    &[],
+                ),
                 (
                     7..14,
                     RunSpecial::NoBreak,
+                    Level::rtl(),
                     Level::new(2).unwrap(),
                     Script::Latin,
                     &[11],
@@ -664,6 +757,7 @@ mod test {
                 (
                     14..25,
                     RunSpecial::None,
+                    Level::rtl(),
                     Level::rtl(),
                     Script::Hebrew,
                     &[15],
@@ -676,8 +770,14 @@ mod test {
     fn test_breaking_weak_bidi() {
         let sample = "123 (1-2)";
 
-        let expected_ltr: Expected =
-            &[(0..9, RunSpecial::None, Level::ltr(), Script::Common, &[4])];
+        let expected_ltr: Expected = &[(
+            0..9,
+            RunSpecial::None,
+            Level::ltr(),
+            Level::ltr(),
+            Script::Common,
+            &[4],
+        )];
         test_breaking(sample, Direction::Auto, &expected_ltr[..]);
         test_breaking(sample, Direction::Ltr, &expected_ltr[..]);
 
@@ -685,6 +785,7 @@ mod test {
             (
                 0..3,
                 RunSpecial::NoBreak,
+                Level::rtl(),
                 Level::new(2).unwrap(),
                 Script::Common,
                 &[],
@@ -693,17 +794,26 @@ mod test {
                 3..5,
                 RunSpecial::NoBreak,
                 Level::rtl(),
+                Level::rtl(),
                 Script::Common,
                 &[4],
             ),
             (
                 5..8,
                 RunSpecial::NoBreak,
+                Level::rtl(),
                 Level::new(2).unwrap(),
                 Script::Common,
                 &[],
             ),
-            (8..9, RunSpecial::None, Level::rtl(), Script::Common, &[]),
+            (
+                8..9,
+                RunSpecial::None,
+                Level::rtl(),
+                Level::rtl(),
+                Script::Common,
+                &[],
+            ),
         ];
         test_breaking(sample, Direction::AutoRtl, &expected_rtl[..]);
         test_breaking(sample, Direction::Rtl, &expected_rtl[..]);
@@ -721,6 +831,7 @@ mod test {
                 0..sample.len(),
                 RunSpecial::None,
                 Level::rtl(),
+                Level::rtl(),
                 Script::Hebrew,
                 &[
                     9, 13, 18, 25, 32, 43, 50, 61, 74, 85, 109, 118, 129, 142, 158, 169, 178, 189,
@@ -737,10 +848,18 @@ mod test {
             sample,
             Direction::Auto,
             &[
-                (0..13, RunSpecial::None, Level::rtl(), Script::Arabic, &[]),
+                (
+                    0..13,
+                    RunSpecial::None,
+                    Level::rtl(),
+                    Level::rtl(),
+                    Script::Arabic,
+                    &[],
+                ),
                 (
                     13..14,
                     RunSpecial::NoBreak,
+                    Level::rtl(),
                     Level::new(2).unwrap(),
                     Script::Common,
                     &[],
@@ -748,6 +867,7 @@ mod test {
                 (
                     14..sample.len(),
                     RunSpecial::None,
+                    Level::rtl(),
                     Level::rtl(),
                     Script::Arabic,
                     &[
@@ -771,12 +891,14 @@ mod test {
                     0..42,
                     RunSpecial::NoBreak,
                     Level::rtl(),
+                    Level::rtl(),
                     Script::Arabic,
                     &[1, 12, 21, 34, 39],
                 ),
                 (
                     42..54,
                     RunSpecial::NoBreak,
+                    Level::rtl(),
                     Level::new(3).unwrap(),
                     Script::Arabic,
                     &[],
@@ -784,6 +906,7 @@ mod test {
                 (
                     54..58,
                     RunSpecial::NoBreak,
+                    Level::rtl(),
                     Level::new(2).unwrap(),
                     Script::Common,
                     &[55],
@@ -792,12 +915,14 @@ mod test {
                     58..197,
                     RunSpecial::NoBreak,
                     Level::rtl(),
+                    Level::rtl(),
                     Script::Arabic,
                     &[62, 69, 82, 91, 107, 118, 127, 138, 153, 166, 179, 196],
                 ),
                 (
                     197..215,
                     RunSpecial::NoBreak,
+                    Level::rtl(),
                     Level::new(2).unwrap(),
                     Script::Latin,
                     &[205],
@@ -806,12 +931,14 @@ mod test {
                     215..244,
                     RunSpecial::None,
                     Level::rtl(),
+                    Level::rtl(),
                     Script::Arabic,
                     &[219, 228, 239],
                 ),
                 (
                     244..246,
                     RunSpecial::NoBreak,
+                    Level::rtl(),
                     Level::new(2).unwrap(),
                     Script::Common,
                     &[],
@@ -820,12 +947,14 @@ mod test {
                     246..247,
                     RunSpecial::NoBreak,
                     Level::rtl(),
+                    Level::rtl(),
                     Script::Common,
                     &[],
                 ),
                 (
                     247..249,
                     RunSpecial::NoBreak,
+                    Level::rtl(),
                     Level::new(2).unwrap(),
                     Script::Common,
                     &[],
@@ -834,12 +963,14 @@ mod test {
                     249..259,
                     RunSpecial::None,
                     Level::rtl(),
+                    Level::rtl(),
                     Script::Arabic,
                     &[250],
                 ),
                 (
                     259..263,
                     RunSpecial::NoBreak,
+                    Level::rtl(),
                     Level::new(2).unwrap(),
                     Script::Common,
                     &[],
@@ -847,6 +978,7 @@ mod test {
                 (
                     263..sample.len(),
                     RunSpecial::None,
+                    Level::rtl(),
                     Level::rtl(),
                     Script::Arabic,
                     &[

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -10,6 +10,7 @@ use crate::conv::{to_u32, to_usize};
 use crate::fonts::{self, FontLibrary};
 use crate::shaper::{GlyphRun, PartMetrics};
 use crate::{Align, Range, Vec2};
+use core::f32;
 use smallvec::SmallVec;
 use std::num::NonZeroUsize;
 use tinyvec::TinyVec;
@@ -408,7 +409,6 @@ struct PartInfo {
     end_space: bool,
 }
 
-#[derive(Default)]
 struct LineAdder {
     wrapped_runs: TinyVec<[RunPart; 1]>,
     parts: Vec<PartInfo>,
@@ -423,11 +423,15 @@ struct LineAdder {
 impl LineAdder {
     fn new(align_width: f32, h_align: Align) -> Self {
         LineAdder {
+            wrapped_runs: Default::default(),
             parts: Vec::with_capacity(16),
+            lines: Default::default(),
+            line_gap: 0.0,
             l_bound: align_width,
+            r_bound: 0.0,
+            vcaret: 0.0,
             h_align,
             align_width,
-            ..Default::default()
         }
     }
 }
@@ -499,9 +503,9 @@ impl PartAccumulator for LineAdder {
         // Iterate runs to determine max ascent, level, etc.
         let mut last_run = u32::MAX;
         let (mut ascent, mut descent, mut line_gap) = (0f32, 0f32, 0f32);
-        let mut line_level = Level::new(Level::max_implicit_depth()).unwrap();
+        let mut base_level = LTR_LEVEL;
         let mut max_level = LTR_LEVEL;
-        for part in parts.iter() {
+        for (i, part) in parts.iter().enumerate() {
             if last_run == part.run {
                 continue;
             }
@@ -513,10 +517,13 @@ impl PartAccumulator for LineAdder {
             descent = descent.min(scale_font.descent());
             line_gap = line_gap.max(scale_font.line_gap());
 
-            line_level = line_level.min(run.level);
+            if i > 0 {
+                // All runs on a line should have the same base (paragraph) level
+                debug_assert_eq!(base_level, run.base_level);
+            }
+            base_level = run.base_level;
             max_level = max_level.max(run.level);
         }
-        let line_is_rtl = line_level.is_rtl();
 
         if !self.lines.is_empty() {
             self.vcaret += line_gap.max(self.line_gap);
@@ -606,6 +613,7 @@ impl PartAccumulator for LineAdder {
             }
         }
 
+        let line_is_rtl = base_level.is_rtl();
         let spare = self.align_width - line_len;
         let mut is_gap = SmallVec::<[bool; 16]>::new();
         let mut per_gap = 0.0;
@@ -634,19 +642,19 @@ impl PartAccumulator for LineAdder {
                 for i in 1..len {
                     let new_level = runs[to_usize(parts[i].run)].level;
                     if level != new_level {
-                        if level > line_level {
+                        if level > base_level {
                             is_gap[start..i].reverse();
                         }
                         start = i;
                         level = new_level;
                     }
                 }
-                if level > line_level {
+                if level > base_level {
                     is_gap[start..len - 1].reverse();
                 }
 
                 // Shift left 1 part for RTL lines
-                if line_level.is_rtl() {
+                if line_is_rtl {
                     is_gap.copy_within(1..len, 0);
                 }
 

--- a/src/display/wrap_lines.rs
+++ b/src/display/wrap_lines.rs
@@ -55,8 +55,7 @@ impl Line {
 impl TextDisplay {
     /// Measure required width, up to some `max_width`
     ///
-    /// [Requires status][Self#status-of-preparation]: level runs have been
-    /// prepared.
+    /// [Requires status][Self#status-of-preparation]: run-breaking is complete.
     ///
     /// This method allows calculation of the width requirement of a text object
     /// without full wrapping and glyph placement. Whenever the requirement
@@ -94,8 +93,7 @@ impl TextDisplay {
     ///
     /// Stops after `max_lines`, if provided.
     ///
-    /// [Requires status][Self#status-of-preparation]: level runs have been
-    /// prepared.
+    /// [Requires status][Self#status-of-preparation]: run-breaking is complete.
     pub fn measure_height(&self, wrap_width: f32, max_lines: Option<NonZeroUsize>) -> f32 {
         #[derive(Default)]
         struct MeasureAdder {
@@ -180,8 +178,7 @@ impl TextDisplay {
 
     /// Prepare lines ("wrap")
     ///
-    /// [Requires status][Self#status-of-preparation]: level runs have been
-    /// prepared.
+    /// [Requires status][Self#status-of-preparation]: run-breaking is complete.
     ///
     /// This does text layout, including wrapping and horizontal alignment but
     /// excluding vertical alignment.

--- a/src/env.rs
+++ b/src/env.rs
@@ -68,3 +68,64 @@ pub enum Direction {
     /// This uses Unicode TR9 HL1 to set an explicit paragraph embedding level of 1.
     Rtl = 1,
 }
+
+impl Direction {
+    /// Is auto-detection enabled?
+    #[inline]
+    pub fn is_auto(self) -> bool {
+        matches!(self, Direction::Auto | Direction::AutoRtl)
+    }
+
+    /// Is this a right-to-left mode (`Rtl` or `AutoRtl`)?
+    #[inline]
+    pub fn is_rtl(self) -> bool {
+        matches!(self, Direction::AutoRtl | Direction::Rtl)
+    }
+
+    /// Get the base directionality of `text`
+    ///
+    /// If <code>self.[is_auto](Direction::is_auto)()</code>, this method uses
+    /// function [`text_is_rtl`] to infer the text direction, falling back to
+    /// [`Self::is_rtl`] on indeterminate texts.
+    /// If <code>!self.[is_auto](Direction::is_auto)()</code>, this method
+    /// simply returns <code>self.[is_rtl](Direction::is_rtl)()</code>.
+    pub fn text_is_rtl(&self, text: &str) -> bool {
+        if self.is_auto()
+            && let Some(is_rtl) = text_is_rtl(text)
+        {
+            is_rtl
+        } else {
+            self.is_rtl()
+        }
+    }
+}
+
+/// Try to infer the base directionality of `text`
+///
+/// This method attempts to infer the base direction of `text` and returns
+/// `Some(is_rtl)` if successful. Specifically, this searches `text` for the
+/// first strongly-directional character (type `L`, `R` or `AL`) up to the end
+/// of the first paragraph and uses this to infer LTR (`L`) or RTL (`R`, `AL`).
+/// See [UAX#9: Bidirectional Character Types](https://www.unicode.org/reports/tr9/#Bidirectional_Character_Types).
+pub fn text_is_rtl(text: &str) -> Option<bool> {
+    match unicode_bidi::get_base_direction(text) {
+        unicode_bidi::Direction::Ltr => Some(false),
+        unicode_bidi::Direction::Rtl => Some(true),
+        unicode_bidi::Direction::Mixed => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn infer_text_dir() {
+        assert_eq!(text_is_rtl("abc"), Some(false));
+        assert_eq!(text_is_rtl("אבג"), Some(true));
+        assert_eq!(text_is_rtl(""), None);
+        assert_eq!(text_is_rtl("123"), None);
+        assert_eq!(text_is_rtl(" 2 - 2 = 0. "), None);
+        assert_eq!(text_is_rtl("123 abc"), Some(false));
+    }
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -5,6 +5,8 @@
 
 //! KAS Rich-Text library — text-display environment
 
+use unicode_bidi::Level;
+
 /// Alignment of contents
 ///
 /// Note that alignment information is often passed as a `(horiz, vert)` pair.
@@ -80,6 +82,14 @@ impl Direction {
     #[inline]
     pub fn is_rtl(self) -> bool {
         matches!(self, Direction::AutoRtl | Direction::Rtl)
+    }
+
+    #[inline]
+    pub(crate) fn level(self) -> Level {
+        match self {
+            Direction::Auto | Direction::Ltr => Level::ltr(),
+            Direction::AutoRtl | Direction::Rtl => Level::rtl(),
+        }
     }
 
     /// Get the base directionality of `text`

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -96,9 +96,16 @@ pub(crate) struct GlyphRun {
     pub face_id: FaceId,
     /// Tab or no-break property
     pub special: RunSpecial,
-    /// BIDI level
+    /// Base BiDi level of the paragraph
+    ///
+    /// We store this here because we don't have anywhere else for per-paragraph
+    /// data (and it is small).
+    pub base_level: Level,
+    /// BiDi level of this run
     pub level: Level,
     /// Script
+    ///
+    /// We store this only to support `resize_runs`.
     pub script: Script,
 
     /// Sequence of all glyphs, in left-to-right order
@@ -230,6 +237,7 @@ pub(crate) struct Input<'a> {
     /// Contiguous text
     pub text: &'a str,
     pub dpem: f32,
+    pub base_level: Level,
     pub level: Level,
     pub script: Script,
 }
@@ -329,6 +337,7 @@ pub(crate) fn shape(
         dpu,
         face_id,
         special,
+        base_level: input.base_level,
         level: input.level,
         script: input.script,
 
@@ -352,6 +361,7 @@ fn shape_rustybuzz(
         dpem,
         level,
         script,
+        ..
     } = input;
 
     let fonts = fonts::library();

--- a/src/text.rs
+++ b/src/text.rs
@@ -308,25 +308,16 @@ impl<T: FormattableText + ?Sized> Text<T> {
         }
     }
 
-    /// Get the base directionality of the text
+    /// Get the base directionality of the first paragraph
     ///
     /// This does not require that the text is prepared.
+    #[inline]
     pub fn text_is_rtl(&self) -> bool {
-        let cached_is_rtl = match self.line_is_rtl(0) {
-            Ok(None) => Some(self.direction == Direction::Rtl),
-            Ok(Some(is_rtl)) => Some(is_rtl),
-            Err(NotReady) => None,
-        };
-        #[cfg(not(debug_assertions))]
-        if let Some(cached) = cached_is_rtl {
-            return cached;
+        if self.status >= Status::ResizeLevelRuns {
+            return self.display.text_is_rtl();
         }
 
-        let is_rtl = self.display.text_is_rtl(self.as_str(), self.direction);
-        if let Some(cached) = cached_is_rtl {
-            debug_assert_eq!(cached, is_rtl);
-        }
-        is_rtl
+        self.direction.text_is_rtl(self.text.as_str())
     }
 
     /// Return the sequence of effect tokens


### PR DESCRIPTION
The removed fn `line_is_rtl` was potentially wrong: it used the level of the logically-first run part on the line, but in case of BiDi lines this could be an embedded run of alternate direction.

~~Since `line_is_rtl` was never really used, it is removed; `TextDisplay::text_is_rtl` now uses a value from analysis during run-breaking.~~

The inference previously used to get the base paragraph direction (min over parts) was wrong sometimes for wrapped lines. We now store `base_level` in struct `GlyphRun` and use this to determine the line level and paragraph direction.