### PR TITLE
Support appending/replacing text (parts) to a `TextDisplay`

### DIFF
--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -16,8 +16,8 @@ mod glyph_pos;
 mod text_runs;
 mod wrap_lines;
 pub use glyph_pos::{GlyphRun, MarkerPos, MarkerPosIter};
-pub use text_runs::RunAppender;
 pub(crate) use text_runs::RunSpecial;
+pub use text_runs::{RunAppender, RunReplacer};
 pub use wrap_lines::Line;
 use wrap_lines::RunPart;
 

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -16,6 +16,7 @@ mod glyph_pos;
 mod text_runs;
 mod wrap_lines;
 pub use glyph_pos::{GlyphRun, MarkerPos, MarkerPosIter};
+pub use text_runs::RunAppender;
 pub(crate) use text_runs::RunSpecial;
 pub use wrap_lines::Line;
 use wrap_lines::RunPart;

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -161,34 +161,34 @@ impl TextDisplay {
         Ok(())
     }
 
-    /// Break text into level runs
+    /// Break `text` into runs, replacing existing content
     ///
-    /// [Requires status][Self#status-of-preparation]: none.
+    /// The `text` is split into a sequence of runs according to the text
+    /// direction, script, font parameters and required font fallbacks (results
+    /// may thus depend on available fonts). These runs are then
+    /// [shaped](https://en.wikipedia.org/wiki/Text_shaping) into glyph
+    /// sequences. [Line wrapping](Self::prepare_lines) should be performed
+    /// after this.
     ///
-    /// The `font_tokens` iterator must not be empty and the first token yielded
+    /// The `font_tokens` iterator controls font selection using
+    /// [`FontToken::start`] indices relative to `text` (byte indices).
+    /// This iterator must not be empty and the first token yielded
     /// must have [`FontToken::start`] == 0. (Failure to do so will result in an
     /// error on debug builds and usage of default values on release builds.)
+    ///
+    /// # Preparation status
+    ///
+    /// [Requires status][Self#status-of-preparation]: none.
     ///
     /// Must be called again if any of `text`, `direction` or `font_tokens`
     /// change.
     /// If only `dpem` changes, [`Self::resize_runs`] may be called instead.
-    ///
-    /// The text is broken into a set of contiguous "level runs". These runs are
-    /// maximal slices of the `text` which do not contain explicit line breaks
-    /// and have a single text direction according to the
-    /// [Unicode Bidirectional Algorithm](http://www.unicode.org/reports/tr9/).
     pub fn prepare_runs(
         &mut self,
         text: &str,
         direction: Direction,
         mut font_tokens: impl Iterator<Item = FontToken>,
     ) -> Result<(), NoFontMatch> {
-        // This method constructs a list of "hard lines" (the initial line and any
-        // caused by a hard break), each composed of a list of "level runs" (the
-        // result of splitting and reversing according to Unicode TR9 aka
-        // Bidirectional algorithm), plus a list of "soft break" positions
-        // (where wrapping may introduce new lines depending on available space).
-
         self.runs.clear();
 
         let (mut dpem, mut font) = read_initial_token(&mut font_tokens);

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -421,7 +421,7 @@ impl TextDisplay {
         // Following a hard break we have an implied empty line.
         if hard_break {
             let range = (text.len()..text.len()).into();
-            input.level = default_para_level.unwrap_or(LTR_LEVEL);
+            input.level = default_level;
             breaks = Default::default();
             self.push_run(font, input, range, breaks, RunSpecial::None, None)?;
         }

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -140,8 +140,42 @@ impl TextDisplay {
     /// This is a low-level alternative to [`Self::prepare_runs`] to support
     /// appending new lines/paragraphs of text.
     /// Optionally call [`Self::clear`] first.
+    ///
+    /// Note: to get the range of runs appended, call [`Self::runs_len`] before
+    /// and after this method.
     pub fn append_runs(&mut self) -> RunAppender<'_> {
         RunAppender { display: self }
+    }
+
+    /// Prepare to replace a `range` of existing text runs
+    ///
+    /// This is a utility designed to allow performant replacements of lines in
+    /// longer text object. If replacing all runs, it is preferable to call
+    /// [`Self::clear`] then use [`Self::append_runs`].
+    ///
+    /// Note: the start of the range of runs appended by this method is
+    /// `range.start` (also the initial value of [`RunReplacer::index`]).
+    /// The end of the range of runs appended by this method is the final
+    /// value of [`RunReplacer::index`].
+    pub fn replace_runs<R>(&mut self, range: R) -> RunReplacer<'_>
+    where
+        R: RangeBounds<usize>,
+    {
+        let index = match range.start_bound() {
+            Bound::Included(start) => *start,
+            Bound::Excluded(start) => start + 1,
+            Bound::Unbounded => 0,
+        };
+        let end = match range.end_bound() {
+            Bound::Included(end) => end - 1,
+            Bound::Excluded(end) => *end,
+            Bound::Unbounded => self.runs.len(),
+        };
+        RunReplacer {
+            display: self,
+            index,
+            end,
+        }
     }
 }
 
@@ -190,6 +224,73 @@ impl<'a> RunAppender<'a> {
         dpem: f32,
     ) -> Result<(), NoFontMatch> {
         PushRun::push_text_range(self, text, range, font, dpem)
+    }
+}
+
+/// A shim for replacing existing text runs
+///
+/// See [`TextDisplay::replace_runs`].
+///
+/// Note: leaking this type (e.g. using [`std::mem::forget`]) may result in
+/// incorrect behaviour.
+pub struct RunReplacer<'a> {
+    display: &'a mut TextDisplay,
+    index: usize,
+    end: usize,
+}
+
+impl<'a> RunReplacer<'a> {
+    /// This is the index at which the next text run will be inserted
+    #[inline]
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Break `text` into runs, appending to existing content
+    ///
+    /// Unlike [`TextDisplay::prepare_runs`] this method appends to existing
+    /// text runs instead of replacing them. This may thus be used to add a text
+    /// in multiple parts (see [`AnalyzedText`] docs for limitations).
+    ///
+    /// If `imply_empty_final_line` and `text` ends with a mandatory line-break
+    /// then an empty text run will be added to represent the final line. This
+    /// should not be used when another text part will be appended after this
+    /// but should be used for the final text part of a multi-line text editor.
+    ///
+    /// # Preparation status
+    ///
+    /// [Requires status][Self#status-of-preparation]: none.
+    #[inline(never)]
+    pub fn push_text(
+        &mut self,
+        text: &AnalyzedText<'_>,
+        font_tokens: impl Iterator<Item = FontToken>,
+        imply_empty_final_line: bool,
+    ) -> Result<(), NoFontMatch> {
+        PushRun::push_text(self, text, font_tokens, imply_empty_final_line)
+    }
+
+    /// Break `&text[range]` into runs, appending to existing content
+    ///
+    /// Unlike [`Self::push_text`] this method appends runs built using a single
+    /// set of font settings.
+    #[inline(never)]
+    pub fn push_text_range(
+        &mut self,
+        text: &AnalyzedText<'_>,
+        range: std::ops::Range<usize>,
+        font: FontSelector,
+        dpem: f32,
+    ) -> Result<(), NoFontMatch> {
+        PushRun::push_text_range(self, text, range, font, dpem)
+    }
+}
+
+impl<'a> Drop for RunReplacer<'a> {
+    fn drop(&mut self) {
+        if self.index < self.end {
+            self.display.runs.drain(self.index..self.end);
+        }
     }
 }
 
@@ -542,6 +643,21 @@ impl<'a> PushRun for RunAppender<'a> {
     #[inline]
     fn push_run(&mut self, run: GlyphRun) {
         self.display.runs.push(run);
+    }
+}
+
+impl<'a> PushRun for RunReplacer<'a> {
+    fn push_run(&mut self, run: GlyphRun) {
+        debug_assert!(self.index <= self.display.runs.len());
+        if self.index < self.end {
+            self.display.runs[self.index] = run;
+        } else if self.index == self.display.runs.len() {
+            self.display.runs.push(run);
+        } else {
+            // TODO(opt): push to a temporary buffer then insert on Drop?
+            self.display.runs.insert(self.index, run);
+        }
+        self.index += 1;
     }
 }
 

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -191,15 +191,8 @@ impl TextDisplay {
     ) -> Result<(), NoFontMatch> {
         self.runs.clear();
 
-        let (mut dpem, mut font) = read_initial_token(&mut font_tokens);
+        let (dpem, mut font) = read_initial_token(&mut font_tokens);
         let mut next_token = font_tokens.next();
-        if let Some(token) = next_token.as_ref()
-            && token.start == 0
-        {
-            font = token.font;
-            dpem = token.dpem;
-            next_token = font_tokens.next();
-        }
 
         let default_para_level = match direction {
             Direction::Auto => None,

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -9,7 +9,7 @@ use super::TextDisplay;
 use crate::conv::{to_u32, to_usize};
 use crate::fonts::{self, FaceId, FontSelector, NoFontMatch};
 use crate::format::FontToken;
-use crate::util::ends_with_hard_break;
+use crate::util::{AnalyzedText, ends_with_hard_break};
 use crate::{Direction, Range, shaper};
 use icu_properties::CodePointMapData;
 use icu_properties::props::{
@@ -19,7 +19,6 @@ use icu_properties::props::{
 use icu_segmenter::LineSegmenter;
 use std::ops::{Bound, RangeBounds};
 use std::sync::OnceLock;
-use unicode_bidi::{BidiInfo, LTR_LEVEL, RTL_LEVEL};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum RunSpecial {
@@ -227,32 +226,16 @@ impl TextDisplay {
         let (dpem, mut font) = read_initial_token(&mut font_tokens);
         let mut next_token = font_tokens.next();
 
-        let default_para_level = match direction {
-            Direction::Auto => None,
-            Direction::AutoRtl => {
-                use unicode_bidi::Direction::*;
-                match unicode_bidi::get_base_direction(text) {
-                    Ltr | Rtl => None,
-                    Mixed => Some(RTL_LEVEL),
-                }
-            }
-            Direction::Ltr => Some(LTR_LEVEL),
-            Direction::Rtl => Some(RTL_LEVEL),
-        };
-        let info = BidiInfo::new(text, default_para_level);
-        let default_level = direction.level();
-        let levels = info.levels;
-        assert_eq!(text.len(), levels.len());
+        let text = AnalyzedText::new(text, direction);
 
         let mut input = shaper::Input {
-            text,
+            text: &text,
             dpem,
-            base_level: info
-                .paragraphs
-                .first()
+            base_level: text
+                .paragraph(0)
                 .map(|p| p.level)
-                .unwrap_or(default_level),
-            level: levels.first().cloned().unwrap_or(default_level),
+                .unwrap_or(text.default_level()),
+            level: text.level(0).unwrap_or(text.default_level()),
             script: Script::Unknown,
         };
         let mut next_para_i = 1;
@@ -262,7 +245,7 @@ impl TextDisplay {
 
         // TODO: allow segmenter configuration
         let segmenter = LineSegmenter::new_auto(Default::default());
-        let mut break_iter = segmenter.segment_str(text);
+        let mut break_iter = segmenter.segment_str(&text);
         let mut next_break = break_iter.next();
 
         let mut first_real = None;
@@ -332,9 +315,9 @@ impl TextDisplay {
             };
 
             // Force end of current run?
-            require_break |= levels
-                .get(index)
-                .map(|level| *level != input.level)
+            require_break |= text
+                .level(index)
+                .map(|level| level != input.level)
                 .unwrap_or(true);
 
             if let Some(token) = next_token.as_ref()
@@ -370,14 +353,14 @@ impl TextDisplay {
 
                 start = index;
                 non_control_end = index;
-                while let Some(para) = info.paragraphs.get(next_para_i)
+                while let Some(para) = text.paragraph(next_para_i)
                     && para.range.start <= index
                 {
                     input.base_level = para.level;
                     next_para_i += 1;
                 }
-                if let Some(level) = levels.get(index) {
-                    input.level = *level;
+                if let Some(level) = text.level(index) {
+                    input.level = level;
                 }
                 input.script = script;
                 breaks = Default::default();
@@ -416,12 +399,12 @@ impl TextDisplay {
             emoji_start = new_emoji_start;
         }
 
-        let hard_break = ends_with_hard_break(text);
+        let hard_break = ends_with_hard_break(&text);
 
         // Following a hard break we have an implied empty line.
         if hard_break {
             let range = (text.len()..text.len()).into();
-            input.level = default_level;
+            input.level = text.default_level();
             breaks = Default::default();
             self.push_run(font, input, range, breaks, RunSpecial::None, None)?;
         }

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -17,6 +17,7 @@ use icu_properties::props::{
     Script,
 };
 use icu_segmenter::LineSegmenter;
+use std::ops::{Bound, RangeBounds};
 use std::sync::OnceLock;
 use unicode_bidi::{BidiInfo, LTR_LEVEL, RTL_LEVEL};
 
@@ -43,21 +44,42 @@ impl TextDisplay {
         self.r_bound = 0.0;
     }
 
-    /// Update font size
+    /// Get the number of text runs
+    #[inline]
+    pub fn runs_len(&self) -> usize {
+        self.runs.len()
+    }
+
+    /// Update font size for existing text runs
     ///
-    /// [Requires status][Self#status-of-preparation]: run-breaking is complete
-    /// excepting that size (`dpem`) alterations may be required.
+    /// [Requires status][Self#status-of-preparation]: run-breaking is complete.
     ///
-    /// Parameters must match those passed to [`Self::prepare_runs`] for the
-    /// result to be valid.
-    ///
-    /// This updates the result of [`TextDisplay::prepare_runs`] due to change
-    /// in font size.
-    pub fn resize_runs(&mut self, text: &str, mut font_tokens: impl Iterator<Item = FontToken>) {
+    /// This is a fast way to resize text. Parameters (aside from
+    /// [`FontToken::dpem`] values) must match those passed to
+    /// [`Self::prepare_runs`]. The passed `range` may be `..` (to update
+    /// everything) or a sub-range (TODO).
+    /// In case a sub-range is used, the `font_tokens` passed may optionally be
+    /// the full set used to construct the text or a sub-set covering the
+    /// text `range` resized here.
+    pub fn resize_runs<R, FT>(&mut self, range: R, text: &str, mut font_tokens: FT)
+    where
+        R: RangeBounds<usize>,
+        FT: Iterator<Item = FontToken>,
+    {
         let (mut dpem, _) = read_initial_token(&mut font_tokens);
         let mut next_token = font_tokens.next();
 
-        for run in &mut self.runs {
+        let start = match range.start_bound() {
+            Bound::Included(start) => *start,
+            Bound::Excluded(start) => start + 1,
+            Bound::Unbounded => 0,
+        };
+        let end = match range.end_bound() {
+            Bound::Included(end) => end - 1,
+            Bound::Excluded(end) => *end,
+            Bound::Unbounded => self.runs.len(),
+        };
+        for run in &mut self.runs[start..end] {
             while let Some(token) = next_token.as_ref() {
                 if token.start > run.range.start {
                     break;

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -56,7 +56,8 @@ impl TextDisplay {
     /// This is a fast way to resize text. Parameters (aside from
     /// [`FontToken::dpem`] values) must match those passed to
     /// [`Self::prepare_runs`]. The passed `range` may be `..` (to update
-    /// everything) or a sub-range (TODO).
+    /// everything) or a sub-range (see [`Self::push_text`] and
+    /// [`AnalyzedText`] docs for limitations on text splitting).
     /// In case a sub-range is used, the `font_tokens` passed may optionally be
     /// the full set used to construct the text or a sub-set covering the
     /// text `range` resized here.
@@ -250,27 +251,71 @@ impl TextDisplay {
         mut font_tokens: impl Iterator<Item = FontToken>,
         imply_empty_final_line: bool,
     ) -> Result<(), NoFontMatch> {
-        let (dpem, mut font) = read_initial_token(&mut font_tokens);
-        let mut next_token = font_tokens.next();
-
-        let mut input = shaper::Input {
-            text: &text,
-            dpem,
-            base_level: text
-                .paragraph(0)
-                .map(|p| p.level)
-                .unwrap_or(text.default_level()),
-            level: text.level(0).unwrap_or(text.default_level()),
-            script: Script::Unknown,
-        };
-        let mut next_para_i = 1;
+        let (mut dpem, mut font) = read_initial_token(&mut font_tokens);
 
         let mut start = 0;
+        for token in font_tokens {
+            let end = to_usize(token.start);
+            self.push_text_range(text, start..end, font, dpem)?;
+
+            start = end;
+            dpem = token.dpem;
+            font = token.font;
+        }
+
+        let len = text.len();
+        if start < len || len == 0 {
+            self.push_text_range(text, start..len, font, dpem)?;
+        }
+
+        // Following a hard break we have an implied empty line.
+        if imply_empty_final_line && ends_with_hard_break(&text) {
+            let input = shaper::Input {
+                text: "",
+                dpem,
+                base_level: text.default_level(),
+                level: text.default_level(),
+                script: Script::Unknown,
+            };
+            let range = (text.len()..text.len()).into();
+            let breaks = Default::default();
+            self.push_run(font, input, range, breaks, RunSpecial::None, None)?;
+        }
+
+        Ok(())
+    }
+
+    /// Break `&text[range]` into runs, appending to existing content
+    ///
+    /// Unlike [`Self::push_text`] this method appends runs built using a single
+    /// set of font settings.
+    pub fn push_text_range(
+        &mut self,
+        text: &AnalyzedText<'_>,
+        range: std::ops::Range<usize>,
+        font: FontSelector,
+        dpem: f32,
+    ) -> Result<(), NoFontMatch> {
+        let starting_para_i = text.find_paragraph(range.start);
+
+        let mut input = shaper::Input {
+            text: &text[range.clone()],
+            dpem,
+            base_level: text
+                .paragraph(starting_para_i)
+                .map(|p| p.level)
+                .unwrap_or(text.default_level()),
+            level: text.level(range.start).unwrap_or(text.default_level()),
+            script: Script::Unknown,
+        };
+        let mut next_para_i = starting_para_i + 1;
+
         let mut breaks = Default::default();
+        let mut start = range.start;
 
         // TODO: allow segmenter configuration
         let segmenter = LineSegmenter::new_auto(Default::default());
-        let mut break_iter = segmenter.segment_str(&text);
+        let mut break_iter = segmenter.segment_str(input.text);
         let mut next_break = break_iter.next();
 
         let mut first_real = None;
@@ -282,10 +327,13 @@ impl TextDisplay {
         let mut last_is_htab = false;
         let mut non_control_end = 0;
 
-        for (index, c) in text
+        for (index, c) in input
+            .text
             .char_indices()
-            .chain(std::iter::once((text.len(), '\0')))
+            .chain(std::iter::once((input.text.len(), '\0')))
         {
+            let index = index + range.start;
+
             // Handling for control chars
             if !last_is_control {
                 non_control_end = index;
@@ -345,12 +393,6 @@ impl TextDisplay {
                 .map(|level| level != input.level)
                 .unwrap_or(true);
 
-            if let Some(token) = next_token.as_ref()
-                && to_usize(token.start) == index
-            {
-                require_break = true;
-            }
-
             if is_real(script) && script != input.script {
                 require_break |= is_real(input.script);
             }
@@ -405,31 +447,9 @@ impl TextDisplay {
                 first_real = Some(c);
             }
 
-            if let Some(token) = next_token.as_ref()
-                && to_usize(token.start) == index
-            {
-                font = token.font;
-                input.dpem = token.dpem;
-                next_token = font_tokens.next();
-                debug_assert!(
-                    next_token
-                        .as_ref()
-                        .map(|token| to_usize(token.start) > index)
-                        .unwrap_or(true)
-                );
-            }
-
             last_is_control = is_control;
             last_is_htab = is_htab;
             emoji_start = new_emoji_start;
-        }
-
-        // Following a hard break we have an implied empty line.
-        if imply_empty_final_line && ends_with_hard_break(&text) {
-            let range = (text.len()..text.len()).into();
-            input.level = text.default_level();
-            breaks = Default::default();
-            self.push_run(font, input, range, breaks, RunSpecial::None, None)?;
         }
 
         /*

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -219,14 +219,39 @@ impl TextDisplay {
         &mut self,
         text: &str,
         direction: Direction,
-        mut font_tokens: impl Iterator<Item = FontToken>,
+        font_tokens: impl Iterator<Item = FontToken>,
     ) -> Result<(), NoFontMatch> {
         self.clear();
+        let text = AnalyzedText::new(text, direction);
+        self.push_text(&text, font_tokens, true)?;
+        Ok(())
+    }
 
+    /// Break `text` into runs, appending to existing content
+    ///
+    /// Unlike [`Self::prepare_runs`] this method appends to existing text runs
+    /// instead of replacing them. This may thus be used to add a text in
+    /// multiple parts (see [`AnalyzedText`] docs for limitations).
+    ///
+    /// If `imply_empty_final_line` and `text` ends with a mandatory line-break
+    /// then an empty text run will be added to represent the final line. This
+    /// should not be used when another text part will be appended after this
+    /// but should be used for the final text part of a multi-line text editor.
+    ///
+    /// # Preparation status
+    ///
+    /// [Requires status][Self#status-of-preparation]: none.
+    ///
+    /// Optionally call [`Self::clear`] before this method to remove old
+    /// content.
+    pub fn push_text(
+        &mut self,
+        text: &AnalyzedText<'_>,
+        mut font_tokens: impl Iterator<Item = FontToken>,
+        imply_empty_final_line: bool,
+    ) -> Result<(), NoFontMatch> {
         let (dpem, mut font) = read_initial_token(&mut font_tokens);
         let mut next_token = font_tokens.next();
-
-        let text = AnalyzedText::new(text, direction);
 
         let mut input = shaper::Input {
             text: &text,
@@ -399,10 +424,8 @@ impl TextDisplay {
             emoji_start = new_emoji_start;
         }
 
-        let hard_break = ends_with_hard_break(&text);
-
         // Following a hard break we have an implied empty line.
-        if hard_break {
+        if imply_empty_final_line && ends_with_hard_break(&text) {
             let range = (text.len()..text.len()).into();
             input.level = text.default_level();
             breaks = Default::default();

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -10,7 +10,7 @@ use crate::conv::{to_u32, to_usize};
 use crate::fonts::{self, FaceId, FontSelector, NoFontMatch};
 use crate::format::FontToken;
 use crate::util::{AnalyzedText, ends_with_hard_break};
-use crate::{Direction, Range, shaper};
+use crate::{Direction, Range, shaper, shaper::GlyphRun};
 use icu_properties::CodePointMapData;
 use icu_properties::props::{
     BinaryProperty, DefaultIgnorableCodePoint, EmojiModifier, EmojiPresentation, RegionalIndicator,
@@ -56,7 +56,7 @@ impl TextDisplay {
     /// This is a fast way to resize text. Parameters (aside from
     /// [`FontToken::dpem`] values) must match those passed to
     /// [`Self::prepare_runs`]. The passed `range` may be `..` (to update
-    /// everything) or a sub-range (see [`Self::push_text`] and
+    /// everything) or a sub-range (see [`RunAppender::push_text`] and
     /// [`AnalyzedText`] docs for limitations on text splitting).
     /// In case a sub-range is used, the `font_tokens` passed may optionally be
     /// the full set used to construct the text or a sub-set covering the
@@ -101,11 +101,106 @@ impl TextDisplay {
         }
     }
 
+    /// Break `text` into runs, replacing existing content
+    ///
+    /// The `text` is split into a sequence of runs according to the text
+    /// direction, script, font parameters and required font fallbacks (results
+    /// may thus depend on available fonts). These runs are then
+    /// [shaped](https://en.wikipedia.org/wiki/Text_shaping) into glyph
+    /// sequences. [Line wrapping](Self::prepare_lines) should be performed
+    /// after this.
+    ///
+    /// The `font_tokens` iterator controls font selection using
+    /// [`FontToken::start`] indices relative to `text` (byte indices).
+    /// This iterator must not be empty and the first token yielded
+    /// must have [`FontToken::start`] == 0. (Failure to do so will result in an
+    /// error on debug builds and usage of default values on release builds.)
+    ///
+    /// # Preparation status
+    ///
+    /// [Requires status][Self#status-of-preparation]: none.
+    ///
+    /// Must be called again if any of `text`, `direction` or `font_tokens`
+    /// change.
+    /// If only `dpem` changes, [`Self::resize_runs`] may be called instead.
+    pub fn prepare_runs(
+        &mut self,
+        text: &str,
+        direction: Direction,
+        font_tokens: impl Iterator<Item = FontToken>,
+    ) -> Result<(), NoFontMatch> {
+        self.clear();
+        let text = AnalyzedText::new(text, direction);
+        self.append_runs().push_text(&text, font_tokens, true)?;
+        Ok(())
+    }
+
+    /// Prepare to append text runs
+    ///
+    /// This is a low-level alternative to [`Self::prepare_runs`] to support
+    /// appending new lines/paragraphs of text.
+    /// Optionally call [`Self::clear`] first.
+    pub fn append_runs(&mut self) -> RunAppender<'_> {
+        RunAppender { display: self }
+    }
+}
+
+/// A shim for appending text runs
+///
+/// See [`TextDisplay::append_runs`].
+pub struct RunAppender<'a> {
+    display: &'a mut TextDisplay,
+}
+
+impl<'a> RunAppender<'a> {
+    /// Break `text` into runs, appending to existing content
+    ///
+    /// Unlike [`TextDisplay::prepare_runs`] this method appends to existing
+    /// text runs instead of replacing them. This may thus be used to add a text
+    /// in multiple parts (see [`AnalyzedText`] docs for limitations).
+    ///
+    /// If `imply_empty_final_line` and `text` ends with a mandatory line-break
+    /// then an empty text run will be added to represent the final line. This
+    /// should not be used when another text part will be appended after this
+    /// but should be used for the final text part of a multi-line text editor.
+    ///
+    /// # Preparation status
+    ///
+    /// [Requires status][Self#status-of-preparation]: none.
+    #[inline(never)]
+    pub fn push_text(
+        &mut self,
+        text: &AnalyzedText<'_>,
+        font_tokens: impl Iterator<Item = FontToken>,
+        imply_empty_final_line: bool,
+    ) -> Result<(), NoFontMatch> {
+        PushRun::push_text(self, text, font_tokens, imply_empty_final_line)
+    }
+
+    /// Break `&text[range]` into runs, appending to existing content
+    ///
+    /// Unlike [`Self::push_text`] this method appends runs built using a single
+    /// set of font settings.
+    #[inline(never)]
+    pub fn push_text_range(
+        &mut self,
+        text: &AnalyzedText<'_>,
+        range: std::ops::Range<usize>,
+        font: FontSelector,
+        dpem: f32,
+    ) -> Result<(), NoFontMatch> {
+        PushRun::push_text_range(self, text, range, font, dpem)
+    }
+}
+
+trait PushRun {
+    fn push_run(&mut self, run: GlyphRun);
+
     /// Resolve font face and shape run
     ///
     /// This may sub-divide text as required to find matching fonts.
     #[cfg_attr(test, allow(unused_mut))]
-    fn push_run(
+    fn select_font_and_push_run(
         &mut self,
         font: FontSelector,
         input: shaper::Input,
@@ -170,7 +265,7 @@ impl TextDisplay {
                         rest.remove(0);
                     }
 
-                    self.runs.push(shaper::shape(
+                    self.push_run(shaper::shape(
                         input,
                         sub_range,
                         face,
@@ -189,63 +284,18 @@ impl TextDisplay {
             start: range.start + start,
             end: range.end,
         };
-        self.runs
-            .push(shaper::shape(input, sub_range, face, breaks, special));
+        self.push_run(shaper::shape(input, sub_range, face, breaks, special));
         Ok(())
     }
 
-    /// Break `text` into runs, replacing existing content
-    ///
-    /// The `text` is split into a sequence of runs according to the text
-    /// direction, script, font parameters and required font fallbacks (results
-    /// may thus depend on available fonts). These runs are then
-    /// [shaped](https://en.wikipedia.org/wiki/Text_shaping) into glyph
-    /// sequences. [Line wrapping](Self::prepare_lines) should be performed
-    /// after this.
-    ///
-    /// The `font_tokens` iterator controls font selection using
-    /// [`FontToken::start`] indices relative to `text` (byte indices).
-    /// This iterator must not be empty and the first token yielded
-    /// must have [`FontToken::start`] == 0. (Failure to do so will result in an
-    /// error on debug builds and usage of default values on release builds.)
-    ///
-    /// # Preparation status
-    ///
-    /// [Requires status][Self#status-of-preparation]: none.
-    ///
-    /// Must be called again if any of `text`, `direction` or `font_tokens`
-    /// change.
-    /// If only `dpem` changes, [`Self::resize_runs`] may be called instead.
-    pub fn prepare_runs(
-        &mut self,
-        text: &str,
-        direction: Direction,
-        font_tokens: impl Iterator<Item = FontToken>,
-    ) -> Result<(), NoFontMatch> {
-        self.clear();
-        let text = AnalyzedText::new(text, direction);
-        self.push_text(&text, font_tokens, true)?;
-        Ok(())
-    }
-
-    /// Break `text` into runs, appending to existing content
-    ///
-    /// Unlike [`Self::prepare_runs`] this method appends to existing text runs
-    /// instead of replacing them. This may thus be used to add a text in
-    /// multiple parts (see [`AnalyzedText`] docs for limitations).
+    /// Break `text` into runs and push
     ///
     /// If `imply_empty_final_line` and `text` ends with a mandatory line-break
     /// then an empty text run will be added to represent the final line. This
     /// should not be used when another text part will be appended after this
     /// but should be used for the final text part of a multi-line text editor.
-    ///
-    /// # Preparation status
-    ///
-    /// [Requires status][Self#status-of-preparation]: none.
-    ///
-    /// Optionally call [`Self::clear`] before this method to remove old
-    /// content.
-    pub fn push_text(
+    #[inline(always)]
+    fn push_text(
         &mut self,
         text: &AnalyzedText<'_>,
         mut font_tokens: impl Iterator<Item = FontToken>,
@@ -279,17 +329,15 @@ impl TextDisplay {
             };
             let range = (text.len()..text.len()).into();
             let breaks = Default::default();
-            self.push_run(font, input, range, breaks, RunSpecial::None, None)?;
+            self.select_font_and_push_run(font, input, range, breaks, RunSpecial::None, None)?;
         }
 
         Ok(())
     }
 
-    /// Break `&text[range]` into runs, appending to existing content
-    ///
-    /// Unlike [`Self::push_text`] this method appends runs built using a single
-    /// set of font settings.
-    pub fn push_text_range(
+    /// Break `&text[range]` into runs and push
+    #[inline(always)]
+    fn push_text_range(
         &mut self,
         text: &AnalyzedText<'_>,
         range: std::ops::Range<usize>,
@@ -408,13 +456,12 @@ impl TextDisplay {
                 if is_emoji {
                     let range = (emoji_start..emoji_end).into();
                     let face = emoji_face_id()?;
-                    self.runs
-                        .push(shaper::shape(input, range, face, breaks, special));
+                    self.push_run(shaper::shape(input, range, face, breaks, special));
                 } else {
                     // NOTE: the range may be empty; we need it anyway (unless
                     // we modify the last run's special property).
                     let range = (start..non_control_end).into();
-                    self.push_run(font, input, range, breaks, special, first_real)?;
+                    self.select_font_and_push_run(font, input, range, breaks, special, first_real)?;
                 };
                 first_real = None;
 
@@ -488,6 +535,13 @@ impl TextDisplay {
         }
         */
         Ok(())
+    }
+}
+
+impl<'a> PushRun for RunAppender<'a> {
+    #[inline]
+    fn push_run(&mut self, run: GlyphRun) {
+        self.display.runs.push(run);
     }
 }
 

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -32,6 +32,17 @@ pub(crate) enum RunSpecial {
 }
 
 impl TextDisplay {
+    /// Reset the `TextDisplay`
+    ///
+    /// This removes all text runs, resetting the display.
+    pub fn clear(&mut self) {
+        self.runs.clear();
+        self.wrapped_runs.clear();
+        self.lines.clear();
+        self.l_bound = 0.0;
+        self.r_bound = 0.0;
+    }
+
     /// Update font size
     ///
     /// [Requires status][Self#status-of-preparation]: run-breaking is complete
@@ -189,7 +200,7 @@ impl TextDisplay {
         direction: Direction,
         mut font_tokens: impl Iterator<Item = FontToken>,
     ) -> Result<(), NoFontMatch> {
-        self.runs.clear();
+        self.clear();
 
         let (dpem, mut font) = read_initial_token(&mut font_tokens);
         let mut next_token = font_tokens.next();

--- a/src/format.rs
+++ b/src/format.rs
@@ -115,6 +115,9 @@ impl<F: FormattableText + ?Sized> FormattableText for &F {
 pub struct FontToken {
     /// Index in text at which formatting becomes active
     ///
+    /// Expected: `start <= text.len()`. (Note: text ending with a mandatory
+    /// break implies a following new-line, at least in some cases.)
+    ///
     /// (Note that we use `u32` not `usize` since it can be assumed text length
     /// will never exceed `u32::MAX`.)
     pub start: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ mod text;
 pub use text::*;
 
 mod util;
-pub use util::{LineIterator, Status};
+pub use util::{AnalyzedText, LineIterator, Status};
 
 pub(crate) mod shaper;
 pub use shaper::{Glyph, GlyphId};

--- a/src/text.rs
+++ b/src/text.rs
@@ -387,6 +387,7 @@ impl<T: FormattableText + ?Sized> Text<T> {
                 self.text.font_tokens(self.dpem, self.font),
             )?,
             Status::ResizeLevelRuns => self.display.resize_runs(
+                ..,
                 self.text.as_str(),
                 self.text.font_tokens(self.dpem, self.font),
             ),

--- a/src/util.rs
+++ b/src/util.rs
@@ -104,6 +104,17 @@ impl<'a> AnalyzedText<'a> {
     pub(crate) fn paragraph(&self, index: usize) -> Option<&ParagraphInfo> {
         self.paragraphs.get(index)
     }
+
+    /// Find the index of the paragraph containing the given text `index`
+    pub(crate) fn find_paragraph(&self, index: usize) -> usize {
+        match self
+            .paragraphs
+            .binary_search_by_key(&index, |para| para.range.start)
+        {
+            Ok(i) => i,
+            Err(i) => i.saturating_sub(1),
+        }
+    }
 }
 
 /// Returns `true` when `text` ends with a mandatory break

--- a/src/util.rs
+++ b/src/util.rs
@@ -38,7 +38,8 @@ impl Status {
 
 /// Analyzer for text direction
 ///
-/// This is typically not stored but computed on use.
+/// This is typically not stored but computed on use for one or multiple
+/// paragraphs of text (see [`Self::new`] docs).
 pub struct AnalyzedText<'a> {
     text: &'a str,
     default_level: Level,

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,9 @@
 use icu_properties::{CodePointMapData, props::LineBreak};
 use icu_segmenter::{LineSegmenter, iterators::LineBreakIterator, scaffold::Utf8};
 use std::ops::Range;
+use unicode_bidi::{BidiInfo, LTR_LEVEL, Level, ParagraphInfo, RTL_LEVEL};
+
+use crate::Direction;
 
 /// Describes the state-of-preparation of a [`TextDisplay`][crate::TextDisplay]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Ord, PartialOrd, Hash)]
@@ -33,11 +36,78 @@ impl Status {
     }
 }
 
-/// Returns `true` when `text` ends with a hard break, assuming that it ends
-/// with a valid line break.
+/// Analyzer for text direction
 ///
-/// This filter is copied from icu_segmenter docs.
+/// This is typically not stored but computed on use.
+pub struct AnalyzedText<'a> {
+    text: &'a str,
+    default_level: Level,
+    levels: Vec<Level>,
+    paragraphs: Vec<ParagraphInfo>,
+}
+
+impl<'a> std::ops::Deref for AnalyzedText<'a> {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.text
+    }
+}
+
+impl<'a> AnalyzedText<'a> {
+    /// Analyze a `text`
+    ///
+    /// For correct analysis, `text` should be one or more whole paragraphs
+    /// (i.e. up to and optionally including a mandatory line break).
+    /// It is valid to analyze a multi-paragraph text as a whole or to split
+    /// the text into sub-ranges as yielded by [`LineIterator`] and analyze
+    /// each sub-range separately.
+    pub fn new(text: &'a str, direction: Direction) -> Self {
+        let default_para_level = match direction {
+            Direction::Auto => None,
+            Direction::AutoRtl => {
+                use unicode_bidi::Direction::*;
+                match unicode_bidi::get_base_direction(text) {
+                    Ltr | Rtl => None,
+                    Mixed => Some(RTL_LEVEL),
+                }
+            }
+            Direction::Ltr => Some(LTR_LEVEL),
+            Direction::Rtl => Some(RTL_LEVEL),
+        };
+
+        let info = BidiInfo::new(text, default_para_level);
+        assert_eq!(text.len(), info.levels.len());
+
+        AnalyzedText {
+            text,
+            default_level: direction.level(),
+            levels: info.levels,
+            paragraphs: info.paragraphs,
+        }
+    }
+
+    /// Get the default [`Level`]
+    #[inline]
+    pub(crate) fn default_level(&self) -> Level {
+        self.default_level
+    }
+
+    /// Get the [`Level`] at the given text index
+    #[inline]
+    pub(crate) fn level(&self, index: usize) -> Option<Level> {
+        self.levels.get(index).copied()
+    }
+
+    /// Get paragraph info for the given paragraph index
+    #[inline]
+    pub(crate) fn paragraph(&self, index: usize) -> Option<&ParagraphInfo> {
+        self.paragraphs.get(index)
+    }
+}
+
+/// Returns `true` when `text` ends with a mandatory break
 pub(crate) fn ends_with_hard_break(text: &str) -> bool {
+    // This filter is copied from icu_segmenter docs.
     text.chars().next_back().is_some_and(|c| {
         matches!(
             CodePointMapData::<LineBreak>::new().get(c),


### PR DESCRIPTION
# Summary

Adds lower-level methods for adding text to a `TextDisplay`, supporting adding a text in parts. Also supports replacing text parts.

# Motivation

The existing design is a poor fit for text editors and potentially also for viewing large documents for performance reasons: it requires (re)-preparing all text at once.

This new API supports splitting a source text at line-breaks and adding each part independently, appending to or replacing old content.

Currently text-wrapping and alignment must still happen for all content afterwards; this could be addressed in the future (if necessary) but is relatively cheap.