### PR TITLE
Fixes; replace fn prepare_runs with fn set_text

### DIFF
--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -16,8 +16,8 @@ mod glyph_pos;
 mod text_runs;
 mod wrap_lines;
 pub use glyph_pos::{GlyphRun, MarkerPos, MarkerPosIter};
+pub use text_runs::RunAppender;
 pub(crate) use text_runs::RunSpecial;
-pub use text_runs::{RunAppender, RunReplacer};
 pub use wrap_lines::Line;
 use wrap_lines::RunPart;
 

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -16,7 +16,7 @@ mod glyph_pos;
 mod text_runs;
 mod wrap_lines;
 pub use glyph_pos::{GlyphRun, MarkerPos, MarkerPosIter};
-pub use text_runs::RunAppender;
+pub use text_runs::Appender;
 pub(crate) use text_runs::RunSpecial;
 pub use wrap_lines::Line;
 use wrap_lines::RunPart;

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -100,74 +100,81 @@ impl TextDisplay {
     /// Must be called again if any of `text`, `direction` or `font_tokens`
     /// change.
     /// If only `dpem` changes, [`Self::resize_runs`] may be called instead.
+    #[deprecated(since = "0.10.0", note = "use Self::set_text instead")]
+    #[inline]
     pub fn prepare_runs(
         &mut self,
         text: &str,
         direction: Direction,
         font_tokens: impl Iterator<Item = FontToken>,
     ) -> Result<(), NoFontMatch> {
-        self.clear();
-        let text = AnalyzedText::new(text, direction);
-        self.append_runs().push_text(&text, font_tokens, true)?;
+        self.set_text(text, direction)
+            .with_tokens(font_tokens, true)?;
         Ok(())
     }
 
-    /// Prepare to append text runs
+    /// Replace prior content and typeset
     ///
-    /// This is a low-level alternative to [`Self::prepare_runs`] to support
-    /// appending new lines/paragraphs of text.
-    /// Optionally call [`Self::clear`] first.
-    pub fn append_runs(&mut self) -> RunAppender<'_> {
-        RunAppender { display: self }
+    /// This method performs most demanding typesetting steps: run-breaking,
+    /// font matching and [shaping](https://en.wikipedia.org/wiki/Text_shaping).
+    ///
+    /// This method may be called from any
+    /// [state of preparation]([Self#status-of-preparation]) but
+    /// [`Self::prepare_lines`] should be called afterwards.
+    ///
+    /// By itself this method does nothing; see the methods on [`Appender`].
+    //
+    // Note: the only real difficulty in adding `fn push_text(..)` (to support
+    // using multiple disjoint pieces of text) is that text indices get used in
+    // various places; such a method would need to offset all text indices used
+    // in GlyphRun to make them distinct and correctly ordered.
+    #[must_use = "set_text(..) has no effect without also calling a method on the return value"]
+    pub fn set_text<'a>(&'a mut self, text: &'a str, direction: Direction) -> Appender<'a> {
+        self.clear();
+        Appender {
+            display: self,
+            text: AnalyzedText::new(text, direction),
+        }
     }
 }
 
 /// A shim for appending text runs
 ///
-/// See [`TextDisplay::append_runs`].
-pub struct RunAppender<'a> {
+/// See [`TextDisplay::set_text`].
+#[must_use]
+pub struct Appender<'a> {
     display: &'a mut TextDisplay,
+    text: AnalyzedText<'a>,
 }
 
-impl<'a> RunAppender<'a> {
-    /// Break `text` into runs, appending to existing content
-    ///
-    /// Unlike [`TextDisplay::prepare_runs`] this method appends to existing
-    /// text runs instead of replacing them. This may thus be used to add a text
-    /// in multiple parts (see [`AnalyzedText`] docs for limitations).
+impl<'a> Appender<'a> {
+    /// Append the entire `text` using fonts inferred from `tokens`
     ///
     /// If `imply_empty_final_line` and `text` ends with a mandatory line-break
     /// then an empty text run will be added to represent the final line. This
     /// should not be used when another text part will be appended after this
     /// but should be used for the final text part of a multi-line text editor.
-    ///
-    /// # Preparation status
-    ///
-    /// [Requires status][Self#status-of-preparation]: none.
     #[inline(never)]
-    pub fn push_text(
-        &mut self,
-        text: &AnalyzedText<'_>,
+    pub fn with_tokens(
+        self,
         font_tokens: impl Iterator<Item = FontToken>,
         imply_empty_final_line: bool,
     ) -> Result<(), NoFontMatch> {
         self.display
-            .push_text(text, font_tokens, imply_empty_final_line)
+            .push_text(&self.text, font_tokens, imply_empty_final_line)
     }
 
-    /// Break `&text[range]` into runs, appending to existing content
-    ///
-    /// Unlike [`Self::push_text`] this method appends runs built using a single
-    /// set of font settings.
+    /// Append `&text[range]` using a single font
     #[inline(never)]
-    pub fn push_text_range(
+    pub fn with_font(
         &mut self,
-        text: &AnalyzedText<'_>,
         range: std::ops::Range<usize>,
         font: FontSelector,
         dpem: f32,
-    ) -> Result<(), NoFontMatch> {
-        self.display.push_text_range(text, range, font, dpem)
+    ) -> Result<&mut Self, NoFontMatch> {
+        self.display
+            .push_text_range(&self.text, range, font, dpem)?;
+        Ok(self)
     }
 }
 
@@ -683,7 +690,12 @@ mod test {
         });
 
         let mut display = TextDisplay::default();
-        assert!(display.prepare_runs(text, dir, fonts).is_ok());
+        assert!(
+            display
+                .set_text(text, dir)
+                .with_tokens(fonts, false)
+                .is_ok()
+        );
 
         for (i, (run, expected)) in display.runs.iter().zip(expected.iter()).enumerate() {
             assert_eq!(

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -17,7 +17,6 @@ use icu_properties::props::{
     Script,
 };
 use icu_segmenter::LineSegmenter;
-use std::ops::{Bound, RangeBounds};
 use std::sync::OnceLock;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -43,43 +42,21 @@ impl TextDisplay {
         self.r_bound = 0.0;
     }
 
-    /// Get the number of text runs
-    #[inline]
-    pub fn runs_len(&self) -> usize {
-        self.runs.len()
-    }
-
     /// Update font size for existing text runs
     ///
     /// [Requires status][Self#status-of-preparation]: run-breaking is complete.
     ///
     /// This is a fast way to resize text. Parameters (aside from
     /// [`FontToken::dpem`] values) must match those passed to
-    /// [`Self::prepare_runs`]. The passed `range` may be `..` (to update
-    /// everything) or a sub-range (see [`RunAppender::push_text`] and
-    /// [`AnalyzedText`] docs for limitations on text splitting).
-    /// In case a sub-range is used, the `font_tokens` passed may optionally be
-    /// the full set used to construct the text or a sub-set covering the
-    /// text `range` resized here.
-    pub fn resize_runs<R, FT>(&mut self, range: R, text: &str, mut font_tokens: FT)
+    /// [`Self::prepare_runs`].
+    pub fn resize_runs<FT>(&mut self, text: &str, mut font_tokens: FT)
     where
-        R: RangeBounds<usize>,
         FT: Iterator<Item = FontToken>,
     {
         let (mut dpem, _) = read_initial_token(&mut font_tokens);
         let mut next_token = font_tokens.next();
 
-        let start = match range.start_bound() {
-            Bound::Included(start) => *start,
-            Bound::Excluded(start) => start + 1,
-            Bound::Unbounded => 0,
-        };
-        let end = match range.end_bound() {
-            Bound::Included(end) => end - 1,
-            Bound::Excluded(end) => *end,
-            Bound::Unbounded => self.runs.len(),
-        };
-        for run in &mut self.runs[start..end] {
+        for run in &mut self.runs {
             while let Some(token) = next_token.as_ref() {
                 if token.start > run.range.start {
                     break;
@@ -140,9 +117,6 @@ impl TextDisplay {
     /// This is a low-level alternative to [`Self::prepare_runs`] to support
     /// appending new lines/paragraphs of text.
     /// Optionally call [`Self::clear`] first.
-    ///
-    /// Note: to get the range of runs appended, call [`Self::runs_len`] before
-    /// and after this method.
     pub fn append_runs(&mut self) -> RunAppender<'_> {
         RunAppender { display: self }
     }

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -146,37 +146,6 @@ impl TextDisplay {
     pub fn append_runs(&mut self) -> RunAppender<'_> {
         RunAppender { display: self }
     }
-
-    /// Prepare to replace a `range` of existing text runs
-    ///
-    /// This is a utility designed to allow performant replacements of lines in
-    /// longer text object. If replacing all runs, it is preferable to call
-    /// [`Self::clear`] then use [`Self::append_runs`].
-    ///
-    /// Note: the start of the range of runs appended by this method is
-    /// `range.start` (also the initial value of [`RunReplacer::index`]).
-    /// The end of the range of runs appended by this method is the final
-    /// value of [`RunReplacer::index`].
-    pub fn replace_runs<R>(&mut self, range: R) -> RunReplacer<'_>
-    where
-        R: RangeBounds<usize>,
-    {
-        let index = match range.start_bound() {
-            Bound::Included(start) => *start,
-            Bound::Excluded(start) => start + 1,
-            Bound::Unbounded => 0,
-        };
-        let end = match range.end_bound() {
-            Bound::Included(end) => end - 1,
-            Bound::Excluded(end) => *end,
-            Bound::Unbounded => self.runs.len(),
-        };
-        RunReplacer {
-            display: self,
-            index,
-            end,
-        }
-    }
 }
 
 /// A shim for appending text runs
@@ -224,73 +193,6 @@ impl<'a> RunAppender<'a> {
         dpem: f32,
     ) -> Result<(), NoFontMatch> {
         PushRun::push_text_range(self, text, range, font, dpem)
-    }
-}
-
-/// A shim for replacing existing text runs
-///
-/// See [`TextDisplay::replace_runs`].
-///
-/// Note: leaking this type (e.g. using [`std::mem::forget`]) may result in
-/// incorrect behaviour.
-pub struct RunReplacer<'a> {
-    display: &'a mut TextDisplay,
-    index: usize,
-    end: usize,
-}
-
-impl<'a> RunReplacer<'a> {
-    /// This is the index at which the next text run will be inserted
-    #[inline]
-    pub fn index(&self) -> usize {
-        self.index
-    }
-
-    /// Break `text` into runs, appending to existing content
-    ///
-    /// Unlike [`TextDisplay::prepare_runs`] this method appends to existing
-    /// text runs instead of replacing them. This may thus be used to add a text
-    /// in multiple parts (see [`AnalyzedText`] docs for limitations).
-    ///
-    /// If `imply_empty_final_line` and `text` ends with a mandatory line-break
-    /// then an empty text run will be added to represent the final line. This
-    /// should not be used when another text part will be appended after this
-    /// but should be used for the final text part of a multi-line text editor.
-    ///
-    /// # Preparation status
-    ///
-    /// [Requires status][Self#status-of-preparation]: none.
-    #[inline(never)]
-    pub fn push_text(
-        &mut self,
-        text: &AnalyzedText<'_>,
-        font_tokens: impl Iterator<Item = FontToken>,
-        imply_empty_final_line: bool,
-    ) -> Result<(), NoFontMatch> {
-        PushRun::push_text(self, text, font_tokens, imply_empty_final_line)
-    }
-
-    /// Break `&text[range]` into runs, appending to existing content
-    ///
-    /// Unlike [`Self::push_text`] this method appends runs built using a single
-    /// set of font settings.
-    #[inline(never)]
-    pub fn push_text_range(
-        &mut self,
-        text: &AnalyzedText<'_>,
-        range: std::ops::Range<usize>,
-        font: FontSelector,
-        dpem: f32,
-    ) -> Result<(), NoFontMatch> {
-        PushRun::push_text_range(self, text, range, font, dpem)
-    }
-}
-
-impl<'a> Drop for RunReplacer<'a> {
-    fn drop(&mut self) {
-        if self.index < self.end {
-            self.display.runs.drain(self.index..self.end);
-        }
     }
 }
 
@@ -642,21 +544,6 @@ impl<'a> PushRun for RunAppender<'a> {
     #[inline]
     fn push_run(&mut self, run: GlyphRun) {
         self.display.runs.push(run);
-    }
-}
-
-impl<'a> PushRun for RunReplacer<'a> {
-    fn push_run(&mut self, run: GlyphRun) {
-        debug_assert!(self.index <= self.display.runs.len());
-        if self.index < self.end {
-            self.display.runs[self.index] = run;
-        } else if self.index == self.display.runs.len() {
-            self.display.runs.push(run);
-        } else {
-            // TODO(opt): push to a temporary buffer then insert on Drop?
-            self.display.runs.insert(self.index, run);
-        }
-        self.index += 1;
     }
 }
 

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -394,23 +394,23 @@ impl TextDisplay {
         let mut last_is_htab = false;
         let mut non_control_end = 0;
 
-        for (index, c) in input.text[range.clone()]
+        for (sub_index, c) in input.text[range.clone()]
             .char_indices()
             .chain(std::iter::once((range.len(), '\0')))
         {
-            let index = index + range.start;
+            let text_index = sub_index + range.start;
 
             // Handling for control chars
             if !last_is_control {
-                non_control_end = index;
+                non_control_end = text_index;
             }
             let is_htab = c == '\t';
             let mut require_break = last_is_htab;
             let is_control = c.is_control();
 
             // Is wrapping allowed at this position?
-            let is_break = next_break == Some(index);
-            let hard_break = is_break && ends_with_hard_break(&text[..index]);
+            let is_break = next_break == Some(sub_index);
+            let hard_break = is_break && sub_index > 0 && ends_with_hard_break(&text[..text_index]);
             if is_break {
                 next_break = break_iter.next();
             }
@@ -424,24 +424,24 @@ impl TextDisplay {
                 EmojiBreak::None => false,
                 EmojiBreak::Start => {
                     require_break = true;
-                    new_emoji_start = index;
+                    new_emoji_start = text_index;
                     false
                 }
                 EmojiBreak::Prohibit => {
-                    emoji_end = index;
+                    emoji_end = text_index;
                     true
                 }
                 EmojiBreak::End => {
                     require_break = true;
-                    emoji_end = index;
+                    emoji_end = text_index;
                     debug_assert!(emoji_end > emoji_start);
                     is_emoji = true;
                     false
                 }
                 EmojiBreak::Restart => {
                     require_break = true;
-                    emoji_end = index;
-                    new_emoji_start = index;
+                    emoji_end = text_index;
+                    new_emoji_start = text_index;
                     debug_assert!(emoji_end > emoji_start);
                     is_emoji = true;
                     false
@@ -455,7 +455,7 @@ impl TextDisplay {
 
             // Force end of current run?
             require_break |= text
-                .level(index)
+                .level(text_index)
                 .map(|level| level != input.level)
                 .unwrap_or(true);
 
@@ -463,7 +463,8 @@ impl TextDisplay {
                 require_break |= is_real(input.script);
             }
 
-            if !prohibit_break && (hard_break || require_break) {
+            let is_end = text_index == range.end;
+            if is_end || !prohibit_break && (hard_break || require_break) {
                 let special = match () {
                     _ if hard_break => RunSpecial::HardBreak,
                     _ if last_is_htab => RunSpecial::HTab,
@@ -483,22 +484,22 @@ impl TextDisplay {
                 };
                 first_real = None;
 
-                start = index;
-                non_control_end = index;
+                start = text_index;
+                non_control_end = text_index;
                 while let Some(para) = text.paragraph(next_para_i)
-                    && para.range.start <= index
+                    && para.range.start <= text_index
                 {
                     input.base_level = para.level;
                     next_para_i += 1;
                 }
-                if let Some(level) = text.level(index) {
+                if let Some(level) = text.level(text_index) {
                     input.level = level;
                 }
                 input.script = script;
                 breaks = Default::default();
             } else {
-                if is_break && !is_control && index > start {
-                    breaks.push(shaper::GlyphBreak::new(to_u32(index)));
+                if is_break && !is_control && text_index > start {
+                    breaks.push(shaper::GlyphBreak::new(to_u32(text_index)));
                 }
 
                 if input.script == Script::Unknown

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -422,7 +422,7 @@ trait PushRun {
         // Following a hard break we have an implied empty line.
         if imply_empty_final_line && ends_with_hard_break(&text) {
             let input = shaper::Input {
-                text: "",
+                text: text,
                 dpem,
                 base_level: text.default_level(),
                 level: text.default_level(),
@@ -448,7 +448,7 @@ trait PushRun {
         let starting_para_i = text.find_paragraph(range.start);
 
         let mut input = shaper::Input {
-            text: &text[range.clone()],
+            text: text,
             dpem,
             base_level: text
                 .paragraph(starting_para_i)
@@ -464,7 +464,7 @@ trait PushRun {
 
         // TODO: allow segmenter configuration
         let segmenter = LineSegmenter::new_auto(Default::default());
-        let mut break_iter = segmenter.segment_str(input.text);
+        let mut break_iter = segmenter.segment_str(&input.text[range.clone()]);
         let mut next_break = break_iter.next();
 
         let mut first_real = None;
@@ -476,10 +476,9 @@ trait PushRun {
         let mut last_is_htab = false;
         let mut non_control_end = 0;
 
-        for (index, c) in input
-            .text
+        for (index, c) in input.text[range.clone()]
             .char_indices()
-            .chain(std::iter::once((input.text.len(), '\0')))
+            .chain(std::iter::once((range.len(), '\0')))
         {
             let index = index + range.start;
 

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -315,6 +315,42 @@ impl TextDisplay {
             self.select_font_and_push_run(font, input, range, breaks, RunSpecial::None, None)?;
         }
 
+        /*
+        println!("text: {}", &text[..]);
+        let fonts = fonts::library();
+        for run in &self.runs {
+            let slice = &text[run.range];
+            print!(
+                "\t{:?}, text[{}..{}], script {:?}, {} glyphs: '{}', ",
+                run.level,
+                run.range.start,
+                run.range.end,
+                run.script,
+                run.glyphs.len(),
+                slice
+            );
+            match run.special {
+                RunSpecial::None => (),
+                RunSpecial::HardBreak => print!("HardBreak, "),
+                RunSpecial::NoBreak => print!("NoBreak, "),
+                RunSpecial::HTab => print!("HTab, "),
+            }
+            print!("breaks=[");
+            let mut iter = run.breaks.iter();
+            if let Some(b) = iter.next() {
+                print!("{}", b.index);
+            }
+            for b in iter {
+                print!(", {}", b.index);
+            }
+            print!("]");
+            if let Some(name) = fonts.get_face_store(run.face_id).name_full() {
+                print!(", {name}");
+            }
+            println!();
+        }
+        */
+
         Ok(())
     }
 
@@ -481,41 +517,6 @@ impl TextDisplay {
             emoji_start = new_emoji_start;
         }
 
-        /*
-        println!("text: {}", text);
-        let fonts = fonts::library();
-        for run in &self.runs {
-            let slice = &text[run.range];
-            print!(
-                "\t{:?}, text[{}..{}], script {:?}, {} glyphs: '{}', ",
-                run.level,
-                run.range.start,
-                run.range.end,
-                run.script,
-                run.glyphs.len(),
-                slice
-            );
-            match run.special {
-                RunSpecial::None => (),
-                RunSpecial::HardBreak => print!("HardBreak, "),
-                RunSpecial::NoBreak => print!("NoBreak, "),
-                RunSpecial::HTab => print!("HTab, "),
-            }
-            print!("breaks=[");
-            let mut iter = run.breaks.iter();
-            if let Some(b) = iter.next() {
-                print!("{}", b.index);
-            }
-            for b in iter {
-                print!(", {}", b.index);
-            }
-            print!("]");
-            if let Some(name) = fonts.get_face_store(run.face_id).name_full() {
-                print!(", {name}");
-            }
-            println!();
-        }
-        */
         Ok(())
     }
 

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -302,9 +302,9 @@ impl TextDisplay {
         }
 
         // Following a hard break we have an implied empty line.
-        if imply_empty_final_line && ends_with_hard_break(&text) {
+        if imply_empty_final_line && ends_with_hard_break(text) {
             let input = shaper::Input {
-                text: text,
+                text,
                 dpem,
                 base_level: text.default_level(),
                 level: text.default_level(),
@@ -366,7 +366,7 @@ impl TextDisplay {
         let starting_para_i = text.find_paragraph(range.start);
 
         let mut input = shaper::Input {
-            text: text,
+            text,
             dpem,
             base_level: text
                 .paragraph(starting_para_i)

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -151,7 +151,8 @@ impl<'a> RunAppender<'a> {
         font_tokens: impl Iterator<Item = FontToken>,
         imply_empty_final_line: bool,
     ) -> Result<(), NoFontMatch> {
-        PushRun::push_text(self, text, font_tokens, imply_empty_final_line)
+        self.display
+            .push_text(text, font_tokens, imply_empty_final_line)
     }
 
     /// Break `&text[range]` into runs, appending to existing content
@@ -166,13 +167,11 @@ impl<'a> RunAppender<'a> {
         font: FontSelector,
         dpem: f32,
     ) -> Result<(), NoFontMatch> {
-        PushRun::push_text_range(self, text, range, font, dpem)
+        self.display.push_text_range(text, range, font, dpem)
     }
 }
 
-trait PushRun {
-    fn push_run(&mut self, run: GlyphRun);
-
+impl TextDisplay {
     /// Resolve font face and shape run
     ///
     /// This may sub-divide text as required to find matching fonts.
@@ -512,12 +511,10 @@ trait PushRun {
         */
         Ok(())
     }
-}
 
-impl<'a> PushRun for RunAppender<'a> {
     #[inline]
     fn push_run(&mut self, run: GlyphRun) {
-        self.display.runs.push(run);
+        self.runs.push(run);
     }
 }
 

--- a/src/fonts/resolver.rs
+++ b/src/fonts/resolver.rs
@@ -252,14 +252,14 @@ impl FontSelector {
         if let Some(gf) = self.family.as_generic() {
             debug!(
                 "select: Script::{:?}, GenericFamily::{:?}, {:?}, {:?}, {:?}",
-                &script, gf, &self.weight, &self.width, &self.style
+                script, gf, self.weight, self.width, self.style
             );
 
             query.set_families([gf]);
         } else if let Some(set) = resolver.families.get(&self.family) {
             debug!(
                 "select: Script::{:?}, {:?}, {:?}, {:?}, {:?}",
-                &script, set, &self.weight, &self.width, &self.style
+                script, set, self.weight, self.width, self.style
             );
 
             query.set_families(set.0.iter());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ mod text;
 pub use text::*;
 
 mod util;
-pub use util::{AnalyzedText, LineIterator, Status};
+pub use util::{LineIterator, Status};
 
 pub(crate) mod shaper;
 pub use shaper::{Glyph, GlyphId};

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -540,7 +540,12 @@ mod test {
         });
 
         let mut display = TextDisplay::default();
-        assert!(display.prepare_runs(text, dir, fonts).is_ok());
+        assert!(
+            display
+                .set_text(text, dir)
+                .with_tokens(fonts, false)
+                .is_ok()
+        );
 
         for (i, (run, expected)) in display.raw_runs().iter().zip(expected.iter()).enumerate() {
             assert_eq!(

--- a/src/text.rs
+++ b/src/text.rs
@@ -381,11 +381,10 @@ impl<T: FormattableText + ?Sized> Text<T> {
     #[inline]
     fn prepare_runs(&mut self) -> Result<(), NoFontMatch> {
         match self.status {
-            Status::New => self.display.prepare_runs(
-                self.text.as_str(),
-                self.direction,
-                self.text.font_tokens(self.dpem, self.font),
-            )?,
+            Status::New => self
+                .display
+                .set_text(self.text.as_str(), self.direction)
+                .with_tokens(self.text.font_tokens(self.dpem, self.font), true)?,
             Status::ResizeLevelRuns => self.display.resize_runs(
                 self.text.as_str(),
                 self.text.font_tokens(self.dpem, self.font),

--- a/src/text.rs
+++ b/src/text.rs
@@ -387,7 +387,6 @@ impl<T: FormattableText + ?Sized> Text<T> {
                 self.text.font_tokens(self.dpem, self.font),
             )?,
             Status::ResizeLevelRuns => self.display.resize_runs(
-                ..,
                 self.text.as_str(),
                 self.text.font_tokens(self.dpem, self.font),
             ),

--- a/src/util.rs
+++ b/src/util.rs
@@ -40,7 +40,7 @@ impl Status {
 ///
 /// This is typically not stored but computed on use for one or multiple
 /// paragraphs of text (see [`Self::new`] docs).
-pub struct AnalyzedText<'a> {
+pub(crate) struct AnalyzedText<'a> {
     text: &'a str,
     default_level: Level,
     levels: Vec<Level>,


### PR DESCRIPTION
Fixes for #140:

- Fix text range passed from run-breaking to the shaper
- Fix handling of text indices in fn `push_text_range`
- Ensure `push_text_range` pushes the tail as a text run

Remove support for replacing sub-runs of text within a `TextDisplay` because it does not correctly account for text indices and because I have no need for it.

Replace `fn append_runs` with `set_text` which clears prior content and prepares runs. In part because this is a nicer API and in part because to support pushing multiple text segments we'd need to remap text indices on the `GlyphRun` post-shaping (or equivalent), which we don't currently have code for. (I.e. we could add `fn push_text`, but would need a little extra code.)

Deprecate fn `prepare_runs` because `set_text` has a nicer API.