### PR TITLE
Add feature-gate 'text'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ serde = ["dep:serde", "bitflags/serde"]
 # Optional: expose ab_glyph font face
 ab_glyph = ["dep:ab_glyph"]
 
+# Provide high-level text API
+text = []
+
 [dependencies]
 cfg-if = "1.0.0"
 easy-cast = "0.5.0"

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -6,8 +6,6 @@
 //! Text prepared for display
 
 use crate::conv::to_usize;
-#[allow(unused)]
-use crate::{Direction, Status, Text};
 use crate::{Vec2, shaper};
 use smallvec::SmallVec;
 use tinyvec::TinyVec;
@@ -83,6 +81,9 @@ pub struct NotReady;
 /// To navigate "up" and "down" lines, use [`TextDisplay::text_glyph_pos`] to
 /// get the position of the cursor, [`TextDisplay::find_line`] to get the line
 /// number, then [`TextDisplay::line_index_nearest`] to find the new index.
+///
+/// [`Text`]: crate::Text
+/// [`Status`]: crate::Status
 #[derive(Clone, Debug)]
 pub struct TextDisplay {
     // NOTE: typical numbers of elements:
@@ -202,6 +203,9 @@ impl TextDisplay {
     ///
     /// This returns the direction inferred from the `text` and [`Direction`]
     /// used during run-breaking. See also [`Direction::text_is_rtl`].
+    ///
+    /// [`Direction`]: crate::Direction
+    /// [`Direction::text_is_rtl`]: crate::Direction::text_is_rtl
     #[inline]
     pub fn text_is_rtl(&self) -> bool {
         self.runs
@@ -221,6 +225,8 @@ impl TextDisplay {
     ///
     /// Note: indeterminate lines (e.g. empty lines) have their direction
     /// determined from the passed [`Direction`].
+    ///
+    /// [`Direction`]: crate::Direction
     pub fn line_is_rtl(&self, line: usize) -> Option<bool> {
         if let Some(line) = self.lines.get(line) {
             let first_run = line.run_range.start();

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -8,9 +8,8 @@
 use super::TextDisplay;
 use crate::conv::{to_u32, to_usize};
 use crate::fonts::{self, FaceId, FontSelector, NoFontMatch};
-use crate::format::FontToken;
 use crate::util::{AnalyzedText, ends_with_hard_break};
-use crate::{Direction, Range, shaper, shaper::GlyphRun};
+use crate::{Direction, FontToken, Range, shaper, shaper::GlyphRun};
 use icu_properties::CodePointMapData;
 use icu_properties::props::{
     BinaryProperty, DefaultIgnorableCodePoint, EmojiModifier, EmojiPresentation, RegionalIndicator,

--- a/src/format.rs
+++ b/src/format.rs
@@ -7,9 +7,7 @@
 
 #![allow(deprecated)]
 
-use crate::fonts::FontSelector;
-#[allow(unused)]
-use crate::{Text, TextDisplay};
+use crate::{FontToken, fonts::FontSelector};
 use std::fmt::Debug; // for doc-links
 
 mod plain;
@@ -108,24 +106,4 @@ impl<F: FormattableText + ?Sized> FormattableText for &F {
     fn effect_tokens(&self) -> &[(u32, Self::Effect)] {
         F::effect_tokens(self)
     }
-}
-
-/// Font formatting token
-#[derive(Clone, Debug, PartialEq)]
-pub struct FontToken {
-    /// Index in text at which formatting becomes active
-    ///
-    /// Expected: `start <= text.len()`. (Note: text ending with a mandatory
-    /// break implies a following new-line, at least in some cases.)
-    ///
-    /// (Note that we use `u32` not `usize` since it can be assumed text length
-    /// will never exceed `u32::MAX`.)
-    pub start: u32,
-    /// Font size, in dots-per-em (pixel width of an 'M')
-    ///
-    /// This may be calculated from point size as `pt_size * dpp`, where `dpp`
-    /// is the number of pixels per point (see [`crate::fonts`] documentation).
-    pub dpem: f32,
-    /// Font selector
-    pub font: FontSelector,
 }

--- a/src/format/plain.rs
+++ b/src/format/plain.rs
@@ -5,8 +5,8 @@
 
 //! Implementations for plain text
 
-use super::{FontToken, FormattableText};
-use crate::fonts::FontSelector;
+use super::FormattableText;
+use crate::{FontToken, fonts::FontSelector};
 
 impl FormattableText for str {
     type Effect = ();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,13 +30,16 @@ mod display;
 pub use display::*;
 
 pub mod fonts;
+#[cfg(feature = "text")]
 pub mod format;
 
+#[cfg(feature = "text")]
 mod text;
+#[cfg(feature = "text")]
 pub use text::*;
 
 mod util;
-pub use util::{LineIterator, Status};
+pub use util::{FontToken, LineIterator, Status};
 
 pub(crate) mod shaper;
 pub use shaper::{Glyph, GlyphId};

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -526,7 +526,7 @@ fn shape_simple(
 /// Tests are extensions of those in `display/text_runs.rs`.
 #[cfg(test)]
 mod test {
-    use crate::{Direction, TextDisplay, format::FontToken};
+    use crate::{Direction, FontToken, TextDisplay};
     use std::iter;
     use std::ops::Range;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,7 @@ use icu_segmenter::{LineSegmenter, iterators::LineBreakIterator, scaffold::Utf8}
 use std::ops::Range;
 use unicode_bidi::{BidiInfo, LTR_LEVEL, Level, ParagraphInfo, RTL_LEVEL};
 
-use crate::Direction;
+use crate::{Direction, fonts::FontSelector};
 
 /// Describes the state-of-preparation of a [`TextDisplay`][crate::TextDisplay]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Ord, PartialOrd, Hash)]
@@ -34,6 +34,26 @@ impl Status {
     pub fn is_ready(&self) -> bool {
         *self == Status::Ready
     }
+}
+
+/// Font formatting token
+#[derive(Clone, Debug, PartialEq)]
+pub struct FontToken {
+    /// Index in text at which formatting becomes active
+    ///
+    /// Expected: `start <= text.len()`. (Note: text ending with a mandatory
+    /// break implies a following new-line, at least in some cases.)
+    ///
+    /// (Note that we use `u32` not `usize` since it can be assumed text length
+    /// will never exceed `u32::MAX`.)
+    pub start: u32,
+    /// Font size, in dots-per-em (pixel width of an 'M')
+    ///
+    /// This may be calculated from point size as `pt_size * dpp`, where `dpp`
+    /// is the number of pixels per point (see [`crate::fonts`] documentation).
+    pub dpem: f32,
+    /// Font selector
+    pub font: FontSelector,
 }
 
 /// Analyzer for text direction


### PR DESCRIPTION
The `Text` struct and `format` module (except `FontToken`) are not used by Kas, but kept as examples / a higher level API.