### PR TITLE
Upgrade fontique; support custom line-breaking options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ log = "0.4"
 serde = { version = "1.0.123", features = ["derive"], optional = true }
 ab_glyph = { version = "0.2.10", optional = true }
 swash = "0.2.4"
-fontique = { version = "0.7.0", features = ["icu_properties"] }
+fontique = { version = "0.10.0" }
 icu_properties = "2.2"
 icu_segmenter = "2.2"
 icu_locale = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,9 @@ serde = { version = "1.0.123", features = ["derive"], optional = true }
 ab_glyph = { version = "0.2.10", optional = true }
 swash = "0.2.4"
 fontique = { version = "0.7.0", features = ["icu_properties"] }
-icu_properties = "2.1.1"
-icu_segmenter = "2.1.2"
+icu_properties = "2.2"
+icu_segmenter = "2.2"
+icu_locale = "2.2"
 
 [dependencies.rustybuzz]
 version = "0.20.1"

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -16,6 +16,7 @@ use icu_properties::props::{
     Script,
 };
 use icu_segmenter::LineSegmenter;
+use icu_segmenter::options::{LineBreakStrictness, LineBreakWordOption};
 use std::sync::OnceLock;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -147,6 +148,24 @@ pub struct Appender<'a> {
 }
 
 impl<'a> Appender<'a> {
+    /// Use a custom line-break strictness
+    ///
+    /// This only affects subsequent calls to [`Self::with_tokens`] and [`Self::with_font`].
+    #[inline]
+    pub fn with_line_break_strictness(&mut self, strictness: LineBreakStrictness) -> &mut Self {
+        self.text.lb_opts.strictness = Some(strictness);
+        self
+    }
+
+    /// Use a custom line-break word option
+    ///
+    /// This only affects subsequent calls to [`Self::with_tokens`] and [`Self::with_font`].
+    #[inline]
+    pub fn with_word_break_option(&mut self, word_option: LineBreakWordOption) -> &mut Self {
+        self.text.lb_opts.word_option = Some(word_option);
+        self
+    }
+
     /// Append the entire `text` using fonts inferred from `tokens`
     ///
     /// If `imply_empty_final_line` and `text` ends with a mandatory line-break
@@ -377,8 +396,7 @@ impl TextDisplay {
         let mut breaks = Default::default();
         let mut start = range.start;
 
-        // TODO: allow segmenter configuration
-        let segmenter = LineSegmenter::new_auto(Default::default());
+        let segmenter = LineSegmenter::new_auto(text.lb_opts);
         let mut break_iter = segmenter.segment_str(&input.text[range.clone()]);
         let mut next_break = break_iter.next();
 

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -166,6 +166,15 @@ impl<'a> Appender<'a> {
         self
     }
 
+    /// Specify a content locale (currently only affects line-breaking)
+    ///
+    /// This only affects subsequent calls to [`Self::with_tokens`] and [`Self::with_font`].
+    #[inline]
+    pub fn with_content_locale(&mut self, locale: &'a icu_locale::LanguageIdentifier) -> &mut Self {
+        self.text.lb_opts.content_locale = Some(locale);
+        self
+    }
+
     /// Append the entire `text` using fonts inferred from `tokens`
     ///
     /// If `imply_empty_final_line` and `text` ends with a mandatory line-break

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -8,7 +8,7 @@
 use super::TextDisplay;
 use crate::conv::{to_u32, to_usize};
 use crate::fonts::{self, FaceId, FontSelector, NoFontMatch};
-use crate::util::{AnalyzedText, ends_with_hard_break};
+use crate::util::{AnalyzedText, ends_with_hard_break, to_fontique_script};
 use crate::{Direction, FontToken, Range, shaper, shaper::GlyphRun};
 use icu_properties::CodePointMapData;
 use icu_properties::props::{
@@ -220,7 +220,7 @@ impl TextDisplay {
         first_real: Option<char>,
     ) -> Result<(), NoFontMatch> {
         let fonts = fonts::library();
-        let font_id = fonts.select_font(&font, input.script.into())?;
+        let font_id = fonts.select_font(&font, to_fontique_script(input.script))?;
         let text = &input.text[range.to_std()];
 
         // Find a font face
@@ -568,7 +568,7 @@ fn emoji_face_id() -> Result<FaceId, NoFontMatch> {
     static ONCE: OnceLock<Result<FaceId, NoFontMatch>> = OnceLock::new();
     *ONCE.get_or_init(|| {
         let fonts = fonts::library();
-        let font = fonts.select_font(&FontSelector::EMOJI, Script::Common.into());
+        let font = fonts.select_font(&FontSelector::EMOJI, to_fontique_script(Script::Common));
         font.map(|font_id| fonts.first_face_for(font_id).expect("invalid FontId"))
     })
 }

--- a/src/display/text_runs.rs
+++ b/src/display/text_runs.rs
@@ -153,9 +153,9 @@ impl<'a> Appender<'a> {
     /// then an empty text run will be added to represent the final line. This
     /// should not be used when another text part will be appended after this
     /// but should be used for the final text part of a multi-line text editor.
-    #[inline(never)]
+    #[inline]
     pub fn with_tokens(
-        self,
+        &mut self,
         font_tokens: impl Iterator<Item = FontToken>,
         imply_empty_final_line: bool,
     ) -> Result<(), NoFontMatch> {
@@ -164,7 +164,7 @@ impl<'a> Appender<'a> {
     }
 
     /// Append `&text[range]` using a single font
-    #[inline(never)]
+    #[inline]
     pub fn with_font(
         &mut self,
         range: std::ops::Range<usize>,
@@ -276,7 +276,6 @@ impl TextDisplay {
     /// then an empty text run will be added to represent the final line. This
     /// should not be used when another text part will be appended after this
     /// but should be used for the final text part of a multi-line text editor.
-    #[inline(always)]
     fn push_text(
         &mut self,
         text: &AnalyzedText<'_>,
@@ -354,7 +353,6 @@ impl TextDisplay {
     }
 
     /// Break `&text[range]` into runs and push
-    #[inline(always)]
     fn push_text_range(
         &mut self,
         text: &AnalyzedText<'_>,

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -383,8 +383,7 @@ fn shape_rustybuzz(
         true => rustybuzz::Direction::RightToLeft,
     });
     buffer.push_str(slice);
-    let script: fontique::Script = script.into();
-    let tag = ttf_parser::Tag(u32::from_be_bytes(script.0));
+    let tag = crate::util::to_ttf_parser_tag(script);
     if let Some(script) = rustybuzz::Script::from_iso15924_tag(tag) {
         buffer.set_script(script);
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -195,3 +195,14 @@ impl<'a> Iterator for LineIterator<'a> {
         None
     }
 }
+
+pub(crate) fn to_fontique_script(script: icu_properties::props::Script) -> fontique::Script {
+    let script = icu_locale::subtags::Script::from(script);
+    fontique::Script::from_bytes(script.into_raw())
+}
+
+#[cfg(feature = "rustybuzz")]
+pub(crate) fn to_ttf_parser_tag(script: icu_properties::props::Script) -> ttf_parser::Tag {
+    let script = icu_locale::subtags::Script::from(script);
+    ttf_parser::Tag::from_bytes(&script.into_raw())
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,9 @@
 //! Utility types and traits
 
 use icu_properties::{CodePointMapData, props::LineBreak};
-use icu_segmenter::{LineSegmenter, iterators::LineBreakIterator, scaffold::Utf8};
+use icu_segmenter::{
+    LineSegmenter, iterators::LineBreakIterator, options::LineBreakOptions, scaffold::Utf8,
+};
 use std::ops::Range;
 use unicode_bidi::{BidiInfo, LTR_LEVEL, Level, ParagraphInfo, RTL_LEVEL};
 
@@ -65,6 +67,7 @@ pub(crate) struct AnalyzedText<'a> {
     default_level: Level,
     levels: Vec<Level>,
     paragraphs: Vec<ParagraphInfo>,
+    pub(crate) lb_opts: LineBreakOptions<'a>,
 }
 
 impl<'a> std::ops::Deref for AnalyzedText<'a> {
@@ -104,6 +107,7 @@ impl<'a> AnalyzedText<'a> {
             default_level: direction.level(),
             levels: info.levels,
             paragraphs: info.paragraphs,
+            lb_opts: LineBreakOptions::default(),
         }
     }
 


### PR DESCRIPTION
This exposes [line break options](https://docs.rs/icu_segmenter/latest/icu_segmenter/options/struct.LineBreakOptions.html).

Upgrades fontique which requires some tag conversion code (removed in fontique v0.8).